### PR TITLE
Remove the requirement of down.sh for arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,12 @@ Import the `tyk_demo.postman_collection.json` into your [Postman](https://postma
 # Resetting
 
 If you want to reset your environment then you need to remove the volumes associated with the container as well as the containers themselves. The `down.sh` script can do this for you.
+You do not need to declare which component to remove since the `up.sh` has already registered them in `.bootstrap/bootstrapped_deployments` so the `down.sh` will just read it and stop all those services.
 
 To bring down the containers and delete associated volumes:
 
 ```
 ./down.sh
-```
-
-If you used deployment parameters when running the `up.sh` script, you should also include them when taking the system down. For example, to bring down the standard Tyk deployment and the `analytics` deployment:
-
-```
-./down.sh analytics
 ```
 
 # Redeploying

--- a/down.sh
+++ b/down.sh
@@ -18,7 +18,7 @@ echo "Running docker-compose down: " $command_docker_compose
 eval $command_docker_compose
 if [ "$?" == 0 ]
 then
-  echo "All containers were stoped and removed"
+  echo "All containers were stopped and removed"
 else
  echo "Error occurred during the following the down command."
 fi 

--- a/down.sh
+++ b/down.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
 
 command_docker_compose="docker-compose -f deployments/tyk/docker-compose.yml"
-for var in "$@"
+bootstrapped_deployments_file="./.bootstrap/bootstrapped_deployments"
+if test -f "$bootstrapped_deployments_file"; then
+while IFS= read -r deployment
 do
   #   the `tyk` deployment is already included, so don't duplicate it
-  if [ "$var" != "tyk" ]
+  if [ "$deployment" != "" ] && [ "$deployment" != "tyk" ]
   then
-    command_docker_compose="$command_docker_compose -f deployments/$var/docker-compose.yml"
+    echo "Removing '$deployment' deployment"
+    command_docker_compose="$command_docker_compose -f deployments/$deployment/docker-compose.yml"
   fi
-done
+done < $bootstrapped_deployments_file
+fi
 command_docker_compose="$command_docker_compose -p tyk-pro-docker-demo-extended --project-directory $(pwd) down -v"
+echo "Running docker-compose down: " $command_docker_compose
 eval $command_docker_compose
+if [ "$?" == 0 ]
+then
+  echo "All containers were stoped and removed"
+else
+ echo "Error occurred during the following the down command."
+fi 

--- a/up.sh
+++ b/up.sh
@@ -65,7 +65,7 @@ command_docker_compose="$command_docker_compose -p tyk-pro-docker-demo-extended 
 eval $command_docker_compose
 if [ "$?" != 0 ]
 then
-  echo "Failure occured when started docker-compose"
+  echo "Error occurred when using docker-compose to bring containers up"
   exit
 fi
 

--- a/up.sh
+++ b/up.sh
@@ -79,7 +79,6 @@ then
 fi
 
 # run bootstrap scripts for any feature deployments specified
-echo "bootstrapping the other deployments: "
 for var in "$@"
 do
   # the `tyk` deployment is already included, so don't duplicate it

--- a/up.sh
+++ b/up.sh
@@ -74,7 +74,7 @@ echo "bootstrapping 'tyk' deployment"
 deployments/tyk/bootstrap.sh 2>> bootstrap.log
 if [ "$?" != 0 ]
 then
-  echo "Failure during bootstrap of 'tyk'. For details check bootstrap.log"
+  echo "Error occurred during bootstrap of 'tyk' deployment. Check bootstrap.log for details."
   exit
 fi
 

--- a/up.sh
+++ b/up.sh
@@ -88,7 +88,7 @@ do
     eval "deployments/$var/bootstrap.sh"
     if [ "$?" != 0 ]
     then
-      echo "Failure during bootstrap of $var (check deployments/$var/bootstrap.sh). For details check bootstrap.log"
+      echo "Error occurred during bootstrap of $var, when running deployments/$var/bootstrap.sh. Check bootstrap.log for details."
       exit
     else
       echo "$var" >> ./.bootstrap/bootstrapped_deployments


### PR DESCRIPTION
1. Register the deployments into ./.bootstrap/bootstrapped-deployments during up.sh
2. Read from ./.bootstrap/bootstrapped-deployments during down.sh
3. Added printouts to test if an error has occurred (?$)
4. Added printout of the docker-compose command as I use it very often and since here it's complicated due to many directories I thought printing it to the user would be useful.
(Example: `docker-compose -f deployments/tyk/docker-compose.yml -f deployments/sso/docker-compose.yml -f deployments/tls/docker-compose.yml -p tyk-pro-docker-demo-extended --project-directory /Users/yaara/work/src/github.com/TykTechnologies/tyk-demo ps`)
5. Have updated the README accordingly
6. Added `--remove-orphanes` to remove containers for services not defined in the Compose file.