### PR TITLE
Portal fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,16 @@ sudo apt-get install jq
 
 See the [JQ installation page](https://stedolan.github.io/jq/download/) for other operating systems.
 
-## Step 2: Add Docker Environment variables
+## Step 2: Map Tyk hostnames to localhost IP
+
+Update the `/etc/hosts` file to contain host entries for the Tyk Dashboard and Portal:
+
+```
+127.0.0.1   tyk-portal.localhost
+127.0.0.1   tyk-dashboard.localhost
+```
+
+## Step 3: Add Docker Environment variables
 
 The `tyk/docker-compose.yml` and `tyk2/docker-compose.yml` files use a Docker environment variable to set the dashboard licence. To set this, create a file called `.env` in the root directory of the repo, then set the content of the file as follows, replacing `<YOUR_LICENCE>` with your Dashboard licence:
 
@@ -64,7 +73,7 @@ DASHBOARD_LICENCE=<YOUR_LICENCE>
 
 In addition to this, some features require entries in the `.env` file. These are set automatically by the `up.sh` file, depending on the deployment parameters.
 
-## Step 3: Bring the deployment up
+## Step 4: Bring the deployment up
 
 To bootstrap the system we will run the `up.sh` script, which will run the necessary `docker-compose` and `bootstrap` commands to start the containers and bootstrap the system. 
 
@@ -96,13 +105,13 @@ Multiple features can be deployed at the same time by providing multiple feature
 
 The bootstrap scripts provide feedback on progress in the `bootstrap.log` file.
 
-## Step 4: Log into the Dashboard
+## Step 5: Log into the Dashboard
 
 The bootstrap process provides credentials and other useful information in the terminal output. Check this output for the Dashboard credentials.
 
 When you log into the Dashboard, you will find the imported APIs and Policies are now available.
 
-## Step 5: Import API requests into Postman
+## Step 6: Import API requests into Postman
 
 There is a Postman collection provided which compliments the imported API definitions and Policies. This lets you demonstrate Tyk features and functionality.
 

--- a/deployments/tyk/bootstrap.sh
+++ b/deployments/tyk/bootstrap.sh
@@ -6,7 +6,8 @@ deployment="Tyk"
 log_start_deployment
 bootstrap_progress
 
-dashboard_base_url="http://localhost:3000"
+dashboard_base_url="http://tyk-dashboard.localhost:3000"
+portal_base_url="http://tyk-portal.localhost:3000"
 gateway_base_url="http://localhost:8080"
 
 log_message "Getting Dashboard configuration"
@@ -280,7 +281,7 @@ echo -e "\033[2K
           Password : $dashboard_user_password
    API Credentials : $dashboard_user_api_credentials  
   ▽ Portal
-               URL : $dashboard_base_url$portal_root_path
+               URL : $portal_base_url$portal_root_path
           Username : $portal_user_email
           Password : $portal_user_password  
   ▽ Gateway

--- a/deployments/tyk/data/tyk-dashboard/organisation.json
+++ b/deployments/tyk/data/tyk-dashboard/organisation.json
@@ -2,8 +2,8 @@
     "id": "5e9d9544a1dcd60001d0ed20",
     "owner_name": "Tyk Demo",
     "owner_slug": "",
-    "cname_enabled": false,
-    "cname": "",
+    "cname_enabled": true,
+    "cname": "tyk-portal.localhost:3000",
     "apis": [],
     "sso_enabled": true,
     "hybrid_enabled": true

--- a/deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf
+++ b/deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf
@@ -38,11 +38,13 @@
   "enable_duplicate_slugs": true,
   "show_org_id": true,
   "host_config": {
-    "enable_host_names": false,
+    "enable_host_names": true,
     "disable_org_slug_prefix": true,
     "hostname": "",
     "override_hostname": "localhost:8080",
-    "portal_domains": {},
+    "portal_domains": {
+      "tyk-portal.localhost:3000":"5e9d9544a1dcd60001d0ed20"
+    },
     "portal_root_path": "/portal",
     "generate_secure_paths": false,
     "use_strict_hostmatch": false

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -2,7 +2,7 @@
 
 # Uses the Dashboard API to export API and Policy definitions, overwriting data used to bootstrap the base Tyk deployment
 
-dashboard_base_url="http://localhost:3000"
+dashboard_base_url="http://tyk-dashboard.localhost:3000"
 dashboard_user_api_credentials=$(cat .context-data/dashboard-user-api-credentials)
 
 echo "Exporting APIs"

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -2,7 +2,7 @@
 
 # Uses the Dashboard Admin API to import API and Policy definitions, using data used to bootstrap the base Tyk deployment
 
-dashboard_base_url="http://localhost:3000"
+dashboard_base_url="http://tyk-dashboard.localhost:3000"
 dashboard_admin_api_credentials=$(cat deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf | jq -r .admin_secret)
 
 echo "Importing APIs"


### PR DESCRIPTION
Portal now bound to `tyk-portal.localhost:3000`, and accessible through http://tyk-portal.localhost:3000/portal