### PR TITLE
pin component versions and fix pump confs

### DIFF
--- a/deployments/analytics/docker-compose.yml
+++ b/deployments/analytics/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
   tyk-pump-elasticsearch:
-    image: tykio/tyk-pump-docker-pub:latest
+    image: tykio/tyk-pump-docker-pub:v0.8.5
     networks:
       - tyk
     volumes:

--- a/deployments/analytics/volumes/tyk-pump/pump-elasticsearch.conf
+++ b/deployments/analytics/volumes/tyk-pump/pump-elasticsearch.conf
@@ -26,16 +26,15 @@
     "mongo-pump-aggregate": {
       "name": "mongo-pump-aggregate",
       "meta": {
-        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics"
-      },
-      "use_mixed_collection": true
+        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics",
+        "use_mixed_collection": true
+      }
     },
     "mongo-pump-selective": {
       "name": "mongo-pump-selective",
       "meta": {
         "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics"
-      },
-      "use_mixed_collection": true
+      }
     },
     "elasticsearch": {
       "type": "elasticsearch",

--- a/deployments/mdcb/docker-compose.yml
+++ b/deployments/mdcb/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   tyk-mdcb:
-    image: tykio/tyk-mdcb-docker:latest
+    image: tykio/tyk-mdcb-docker:v1.1.0
     networks:
       - tyk
     volumes:
@@ -12,7 +12,7 @@ services:
       - tyk-redis
       - tyk-mongo
   tyk-worker-gateway:
-    image: tykio/tyk-gateway:latest
+    image: tykio/tyk-gateway:v3.0.0
     ports:
       - 8084:8080
     networks:
@@ -30,7 +30,7 @@ services:
       - tyk-mdcb
       - tyk-dashboard
   tyk-worker-redis:
-    image: redis
+    image: redis:6.0.4
     volumes:
       - tyk-worker-redis-data:/data
     networks:

--- a/deployments/sso/docker-compose.yml
+++ b/deployments/sso/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   tyk-dashboard-sso:
-    image: tykio/tyk-dashboard:latest
+    image: tykio/tyk-dashboard:v3.0.0
     ports:
       - 3001:3000
     networks:

--- a/deployments/tyk/docker-compose.yml
+++ b/deployments/tyk/docker-compose.yml
@@ -1,12 +1,13 @@
 version: '3.3'
 services:
   tyk-dashboard:
-    image: tykio/tyk-dashboard:latest
+    image: tykio/tyk-dashboard:v3.0.0
     ports:
       - 3000:3000
     networks:
       - tyk
     volumes:
+      - ./deployments/tyk/volumes/tyk-dashboard/catalogue.html:/opt/tyk-dashboard/portal/templates/catalogue.html
       - ./deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf:/opt/tyk-dashboard/tyk_analytics.conf
       - ./deployments/tyk/volumes/tyk-dashboard/private-key.pem:/opt/tyk-dashboard/private-key.pem
     environment:
@@ -16,7 +17,7 @@ services:
       - tyk-redis
       - tyk-mongo
   tyk-gateway:
-    image: tykio/tyk-gateway:latest
+    image: tykio/tyk-gateway:v3.0.0
     ports:
       - 8080:8080
     networks:
@@ -31,7 +32,7 @@ services:
     depends_on:
       - tyk-redis
   tyk-gateway-2:
-    image: tykio/tyk-gateway:latest
+    image: tykio/tyk-gateway:v3.0.0
     ports:
       - 8081:8080
     networks:

--- a/deployments/tyk/volumes/tyk-pump/pump.conf
+++ b/deployments/tyk/volumes/tyk-pump/pump.conf
@@ -26,16 +26,18 @@
     "mongo-pump-aggregate": {
       "name": "mongo-pump-aggregate",
       "meta": {
-        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics"
-      },
-      "use_mixed_collection": true
+        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics",
+        "use_mixed_collection": true
+      }
+      
     },
     "mongo-pump-selective": {
       "name": "mongo-pump-selective",
       "meta": {
-        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics"
-      },
-      "use_mixed_collection": true
+        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics",
+        "use_mixed_collection": true
+      }
+      
     }
   },
   "uptime_pump_config": {

--- a/deployments/tyk2/docker-compose.yml
+++ b/deployments/tyk2/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   tyk2-dashboard:
-    image: tykio/tyk-dashboard:latest
+    image: tykio/tyk-dashboard:v3.0.0
     ports:
       - 3002:3000
     networks:
@@ -18,7 +18,7 @@ services:
       - tyk2-redis
       - tyk2-mongo
   tyk2-gateway:
-    image: tykio/tyk-gateway:latest
+    image: tykio/tyk-gateway:v3.0.0
     ports:
       - 8085:8080
     networks:
@@ -33,7 +33,7 @@ services:
     depends_on:
       - tyk2-redis
   tyk2-pump:
-    image: tykio/tyk-pump-docker-pub:latest
+    image: tykio/tyk-pump-docker-pub:v0.8.5
     networks:
       - tyk
     volumes:

--- a/deployments/tyk2/volumes/tyk-pump/pump.conf
+++ b/deployments/tyk2/volumes/tyk-pump/pump.conf
@@ -26,16 +26,15 @@
     "mongo-pump-aggregate": {
       "name": "mongo-pump-aggregate",
       "meta": {
-        "mongo_url": "mongodb://e2-tyk-mongo:27017/tyk_analytics"
-      },
-      "use_mixed_collection": true
+        "mongo_url": "mongodb://e2-tyk-mongo:27017/tyk_analytics",
+        "use_mixed_collection": true
+      }
     },
     "mongo-pump-selective": {
       "name": "mongo-pump-selective",
       "meta": {
         "mongo_url": "mongodb://e2-tyk-mongo:27017/tyk_analytics"
-      },
-      "use_mixed_collection": true
+      }
     }
   },
   "uptime_pump_config": {


### PR DESCRIPTION
1) Pins the component versions to most recent release.
Leaving TiB as "latest" tag because the last stable release is ancient (`0.7.0`)

2) Fixing pump.conf.  The values in pump.conf were in. the wrong place for Aggregate pump and removed a value that doesn't exist for selective pump.

Will now correctly display analytics in the Portal Dashboard:
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/8964621/88698777-7ef74580-d0d4-11ea-8e57-afa2e11093be.png">
