### PR TITLE
Upgrade versions

### DIFF
--- a/deployments/mdcb/docker-compose.yml
+++ b/deployments/mdcb/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - tyk-redis
       - tyk-mongo
   tyk-worker-gateway:
-    image: tykio/tyk-gateway:${GATEWAY_WORKER_VERSION:-v3.1.2}
+    image: tykio/tyk-gateway:${GATEWAY_WORKER_VERSION:-v3.2.1}
     ports:
       - 8084:8080
     networks:

--- a/deployments/sso/docker-compose.yml
+++ b/deployments/sso/docker-compose.yml
@@ -1,13 +1,14 @@
 version: '3.3'
 services:
   tyk-dashboard-sso:
-    image: tykio/tyk-dashboard:${DASHBOARD_SSO_VERSION:-v3.1.0}
+    image: tykio/tyk-dashboard:${DASHBOARD_SSO_VERSION:-v3.2.1}
     ports:
       - 3001:3000
     networks:
       - tyk
     volumes:
       - ./deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf:/opt/tyk-dashboard/tyk_analytics.conf
+      - ./deployments/tyk/volumes/tyk-dashboard/private-key.pem:/opt/tyk-dashboard/private-key.pem
     environment:
       - TYK_DB_LICENSEKEY=${DASHBOARD_LICENCE:?Please set DASHBOARD_LICENCE in .env}
       - TYK_DB_SSOCUSTOMLOGINURL=http://localhost:3010/auth/tyk-dashboard/openid-connect

--- a/deployments/tyk/docker-compose.yml
+++ b/deployments/tyk/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   tyk-dashboard:
-    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.1.2}
+    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.2.0}
     ports:
       - 3000:3000
     networks:
@@ -22,7 +22,7 @@ services:
       - tyk-redis
       - tyk-mongo
   tyk-gateway:
-    image: tykio/tyk-gateway:${GATEWAY_VERSION:-v3.1.2}
+    image: tykio/tyk-gateway:${GATEWAY_VERSION:-v3.2.1}
     ports:
       - 8080:8080
       - 8086:8086
@@ -44,7 +44,7 @@ services:
     depends_on:
       - tyk-redis
   tyk-gateway-2:
-    image: tykio/tyk-gateway:${GATEWAY2_VERSION:-v3.1.2}
+    image: tykio/tyk-gateway:${GATEWAY2_VERSION:-v3.2.1}
     ports:
       - 8081:8080
     networks:

--- a/deployments/tyk/docker-compose.yml
+++ b/deployments/tyk/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   tyk-dashboard:
-    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.2.0}
+    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.2.1}
     ports:
       - 3000:3000
     networks:
@@ -34,6 +34,9 @@ services:
       - TYK_LOGLEVEL=${GATEWAY_LOGLEVEL:-info}
       - TYK_INSTRUMENTATION=${INSTRUMENTATION_ENABLED:-0}
       - TYK_GW_TRACER_ENABLED=${TRACING_ENABLED:-false}
+      - TYK_GW_HTTPSERVEROPTIONS_ENABLEHTTP2=true
+      - TYK_GW_PROXYENABLEHTTP2=true
+      - TYK_GW_HTTPSERVEROPTIONS_FLUSHINTERVAL=1
     env_file:
     - .env
     volumes:

--- a/deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf
+++ b/deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf
@@ -98,5 +98,11 @@
   "enable_update_key_by_hash": true,
   "enable_delete_key_by_hash": true,
   "sso_enable_user_lookup": true,
-  "sso_custom_login_url": ""
+  "sso_custom_login_url": "",
+  "security": {
+    "open_policy": {
+      "enabled": true,
+      "enable_api": true
+    }
+  }
 }

--- a/deployments/tyk2/docker-compose.yml
+++ b/deployments/tyk2/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   tyk2-dashboard:
-    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.1.2}
+    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.2.0}
     ports:
       - 3002:3000
     networks:
@@ -20,7 +20,7 @@ services:
       - tyk2-redis
       - tyk2-mongo
   tyk2-gateway:
-    image: tykio/tyk-gateway:${TYK2_GATEWAY_VERSION:-v3.1.2}
+    image: tykio/tyk-gateway:${TYK2_GATEWAY_VERSION:-v3.2.1}
     ports:
       - 8085:8080
     networks:

--- a/deployments/tyk2/docker-compose.yml
+++ b/deployments/tyk2/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   tyk2-dashboard:
-    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.2.0}
+    image: tykio/tyk-dashboard:${DASHBOARD_VERSION:-v3.2.1}
     ports:
       - 3002:3000
     networks:


### PR DESCRIPTION
Upgrade `tyk-demo` to use new release.  Gateway uses `3.2.1` as version `3.2.0` had a bug with Go/Python plugins, which were fixed in `3.2.1`