### PR TITLE
Adding -T flag to bootstrap.sh for docker-compose v2.2.3 compatibility. 

### DIFF
--- a/deployments/tyk/bootstrap.sh
+++ b/deployments/tyk/bootstrap.sh
@@ -105,7 +105,7 @@ wait_for_response "$dashboard_base_url/admin/organisations" "200" "admin-auth: $
 # Python plugin
 
 log_message "Building Python plugin bundle"
-eval "$(generate_docker_compose_command) exec -d tyk-gateway sh -c \"cd /opt/tyk-gateway/middleware/python/basic-example; /opt/tyk-gateway/tyk bundle build -k /opt/tyk-gateway/certs/private-key.pem\"" 1> /dev/null 2>> bootstrap.log
+eval "$(generate_docker_compose_command) exec -T -d tyk-gateway sh -c \"cd /opt/tyk-gateway/middleware/python/basic-example; /opt/tyk-gateway/tyk bundle build -k /opt/tyk-gateway/certs/private-key.pem\"" 1> /dev/null 2>> bootstrap.log
 if [ "$?" != 0 ]; then
   echo "Error occurred when building Python plugin bundle"
   exit 1


### PR DESCRIPTION
Updating bootstrap.sh to support docker-compose v2.2.3 with -T flag.