### PR TITLE
Use the dashboard hostname instead of docker host hack

### DIFF
--- a/deployments/portal/docker-compose.yml
+++ b/deployments/portal/docker-compose.yml
@@ -18,5 +18,5 @@ services:
       - "--pass=${ADMIN_PASSWORD}"
       - "--provider-name=\"TykPro@localhost\""
       - "--provider-type=tyk-pro"
-      - "--provider-data={\"URL\": \"http://host.docker.internal:3000/\", \"Secret\": \"${TYK_DASHBOARD_API_ACCESS_CREDENTIALS}\", \"OrgID\": \"${ADMIN_ORG_ID}\"}"
+      - "--provider-data={\"URL\": \"http://tyk-dashboard:3000/\", \"Secret\": \"${TYK_DASHBOARD_API_ACCESS_CREDENTIALS}\", \"OrgID\": \"${ADMIN_ORG_ID}\"}"
 


### PR DESCRIPTION
Not all hosts support the `host.docker.internal` namespace.  Using the `tyk-dashboard` service name instead