### PR TITLE
Fix ngrok - error "error response from daemon: invalid restart policy…

### DIFF
--- a/deployments/ngrok/docker-compose.yml
+++ b/deployments/ngrok/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - NGROK_PORT=tyk-gateway:8080
     deploy:
       restart_policy:
-        condition: any
+        condition: on-failure


### PR DESCRIPTION
… 'any'"

When running the ngrok deployment you get "error response from daemon: invalid restart policy 'any'"

Changing restart policy from "any" to "on-failure" fixes the issue