### PR TITLE
Added tyk-mongo to /etc/hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,12 @@ bootstrap.log
 deployments/cicd/volumes/jenkins/bootstrap-import/credentials-global.xml
 deployments/cicd/volumes/jenkins/plugins/*.jpi
 deployments/tyk/volumes/tyk-gateway/middleware/python/basic-example/bundle.zip
-deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.so
-deployments/tyk/volumes/tyk-gateway/plugins/go/ipratelimit/ip-rate-limit.so
+deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin_*.so
+deployments/tyk/volumes/tyk-gateway/plugins/go/ipratelimit/ip-rate-limit_*.so
 deployments/tyk/volumes/tyk-gateway/plugins/go/example/vendor
 deployments/tyk/volumes/http-server/python-basic-example.zip
 deployments/tyk/volumes/tyk-gateway/middleware/bundles
-deployments/tyk/volumes/tyk-gateway/plugins/go/jwt/jwt-go-plugin.so
+deployments/tyk/volumes/tyk-gateway/plugins/go/jwt/jwt-go-plugin_*.so
 deployments/tyk/volumes/tyk-gateway/plugins/go/jwt/vendor
 audit.log
 deployments/tyk/volumes/tyk-gateway/certs/tls-certificate.pem

--- a/.gitignore
+++ b/.gitignore
@@ -4,15 +4,13 @@
 .bootstrap
 .idea/
 bootstrap.log
+**/*.so
 deployments/cicd/volumes/jenkins/bootstrap-import/credentials-global.xml
 deployments/cicd/volumes/jenkins/plugins/*.jpi
 deployments/tyk/volumes/tyk-gateway/middleware/python/basic-example/bundle.zip
-deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin_*.so
-deployments/tyk/volumes/tyk-gateway/plugins/go/ipratelimit/ip-rate-limit_*.so
 deployments/tyk/volumes/tyk-gateway/plugins/go/example/vendor
 deployments/tyk/volumes/http-server/python-basic-example.zip
 deployments/tyk/volumes/tyk-gateway/middleware/bundles
-deployments/tyk/volumes/tyk-gateway/plugins/go/jwt/jwt-go-plugin_*.so
 deployments/tyk/volumes/tyk-gateway/plugins/go/jwt/vendor
 audit.log
 deployments/tyk/volumes/tyk-gateway/certs/tls-certificate.pem

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 # Contains functions useful for bootstrap scripts
 
 # this array defines the hostnames that the bootstrap script will verify, and that the update-hosts script will use to modify /etc/hosts
-declare -a tyk_demo_hostnames=("tyk-dashboard.localhost" "tyk-portal.localhost" "tyk-gateway.localhost" "tyk-gateway-2.localhost" "tyk-custom-domain.com" "tyk-worker-gateway.localhost" "acme-portal.localhost" "go-bench-suite.localhost" "tyk-dynamic-looping.com" "echo-server.localhost" "keycloak")
+declare -a tyk_demo_hostnames=("tyk-dashboard.localhost" "tyk-portal.localhost" "tyk-gateway.localhost" "tyk-gateway-2.localhost" "tyk-custom-domain.com" "tyk-worker-gateway.localhost" "acme-portal.localhost" "go-bench-suite.localhost" "tyk-dynamic-looping.com" "echo-server.localhost" "keycloak" "tyk-mongo")
 
 spinner_chars="/-\|"
 spinner_count=1
@@ -706,3 +706,4 @@ wait_for_liveness () {
 
   done
 }
+


### PR DESCRIPTION
1. Give access to mongo with a mongo client - Update command script with `tyk-mongo` so it's in `/etc/hosts`.
2. Update `.gitignore` to match the new plugin name format