### PR TITLE
Update README.md

### DIFF
--- a/deployments/analytics-kibana/README.md
+++ b/deployments/analytics-kibana/README.md
@@ -14,7 +14,7 @@ Run the `up.sh` script with the `analytics` parameter:
 
 ### Postman Collection
 
-You can import the deployment-specific Postman collection `tyk_demo_analytics.postman_collection.json`.
+You can import the deployment-specific Postman collection `tyk_demo_analytics_kibana.postman_collection.json`.
 
 ## Analytics data processing
 


### PR DESCRIPTION
In the Postman Collection section the json file is called `tyk_demo_analytics.postman_collection` when it should be called `tyk_demo_analytics_kibana.postman_collection`. Let me know if this is true since I couldn't find the `tyk_demo_analytics.postman_collection` and in the splunk deployment it has the specific splunk collection at the Postman Collection Section.