### PR TITLE
Plugin request response share data

### DIFF
--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
@@ -335,6 +335,12 @@
     "custom_middleware": {
       "pre": [
         {
+          "name": "WriteDataToContext",
+          "path": "plugins/go/example/example-go-plugin.so",
+          "require_session": false,
+          "raw_body_only": false
+        },
+        {
           "name": "RequestLogger",
           "path": "plugins/go/example/example-go-plugin.so",
           "require_session": false,
@@ -356,7 +362,12 @@
         "require_session": false,
         "raw_body_only": false
       },
-      "response": [],
+      "response": [
+        {
+        "name": "AddContextDataToResponse",
+        "path": "plugins/go/example/example-go-plugin.so"
+        }
+      ],
       "driver": "goplugin",
       "id_extractor": {
         "extract_from": "",

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
@@ -336,9 +336,7 @@
       "pre": [
         {
           "name": "WriteDataToContext",
-          "path": "plugins/go/example/example-go-plugin.so",
-          "require_session": false,
-          "raw_body_only": false
+          "path": "plugins/go/example/example-go-plugin.so"
         },
         {
           "name": "RequestLogger",
@@ -364,8 +362,8 @@
       },
       "response": [
         {
-        "name": "AddContextDataToResponse",
-        "path": "plugins/go/example/example-go-plugin.so"
+          "name": "AddContextDataToResponse",
+          "path": "plugins/go/example/example-go-plugin.so"
         }
       ],
       "driver": "goplugin",

--- a/deployments/tyk/tyk_demo_tyk.postman_collection.json
+++ b/deployments/tyk/tyk_demo_tyk.postman_collection.json
@@ -228,6 +228,43 @@
 								"description": "This request uses a Go plugin to take the JWT provided in the `authorization` header, parse it, extract the value of the `pol` payload property then add the value to the request as a header.\n\nThe value can be see in the `headers.X-Jwt-Policy-Id` JSON property of the response body.\n\nThe API itself doesn't use authentication or process the JWT in any other way. It's purely an example of using a Go plugin."
 							},
 							"response": []
+						},
+						{
+							"name": "Middleware - Go - Context Data & Response",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Context data is returned in response header\", function () {",
+											"    pm.response.to.have.header(\"Data-From-Context\", \"MyContextData\")",
+											"});",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://{{tyk-gateway.host}}/go-plugin-api-no-auth/get",
+									"protocol": "http",
+									"host": [
+										"{{tyk-gateway.host}}"
+									],
+									"path": [
+										"go-plugin-api-no-auth",
+										"get"
+									]
+								},
+								"description": "This request shows two things:\n\n1. Passing of data between plugin functions.\n2. Running plugins for the response.\n\nThe first, passing data between plugin functions, is achieved using the context object. In this example, the `WriteDataToContext` function is executed during the request phase. It writes a key value pair to the context; `MyContextDataKey` / `MyContextData`. \n\nThe data is then retrieved later in the response phase by the `AddContextDataToResponse` function, which extracts the data from the request context. This also serves as the second part of this example, by executing the plugin on the response to write the data as a header; `Data-From-Context` / `MyContextValue`."
+							},
+							"response": []
 						}
 					]
 				},

--- a/deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go
+++ b/deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go
@@ -172,9 +172,13 @@ func AddHelloWorldHeader(rw http.ResponseWriter, r *http.Request) {
 func WriteDataToContext(rw http.ResponseWriter, r *http.Request) {
 	logger.Info("WriteDataToContext is called")
 
+	// copy the request context
 	ctx := r.Context()
+	// add the data
 	ctx = context.WithValue(ctx, "MyContextDataKey", "MyContextData")
+	// copy the request object, but with new context
 	r2 := r.WithContext(ctx)
+	// replace request object with new version
 	*r = *r2
 }
 
@@ -183,9 +187,11 @@ func AddContextDataToResponse(rw http.ResponseWriter, res *http.Response, req *h
 	logger.Info("AddContextDataToResponse is called")
 
 	ctx := req.Context()
+	// get the data
 	myContextData := ctx.Value("MyContextDataKey")
-
+	// check that it isn't nil
 	if myContextData != nil {
+		// add it as a response header
 		res.Header.Add("Data-From-Context", myContextData.(string))
 	}
 }

--- a/deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go
+++ b/deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -165,6 +166,28 @@ func Authenticate(rw http.ResponseWriter, r *http.Request) {
 // AddHelloWorldHeader adds custom "Hello: World" header to the request
 func AddHelloWorldHeader(rw http.ResponseWriter, r *http.Request) {
 	r.Header.Add("Hello", "World")
+}
+
+// Writes a string data to the context, which can then be read later
+func WriteDataToContext(rw http.ResponseWriter, r *http.Request) {
+	logger.Info("WriteDataToContext is called")
+
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, "MyContextDataKey", "MyContextData")
+	r2 := r.WithContext(ctx)
+	*r = *r2
+}
+
+// Reads data from the context and adds it to the response
+func AddContextDataToResponse(rw http.ResponseWriter, res *http.Response, req *http.Request) {
+	logger.Info("AddContextDataToResponse is called")
+
+	ctx := req.Context()
+	myContextData := ctx.Value("MyContextDataKey")
+
+	if myContextData != nil {
+		res.Header.Add("Data-From-Context", myContextData.(string))
+	}
 }
 
 // Called once plugin is loaded, this is where we put all initialization work for plugin


### PR DESCRIPTION
Adds example of a Go plugin that passes data between different hooks, and also executes as part of the response.