### PR TITLE
Added analytics function to existing example go plugin

### DIFF
--- a/deployments/tyk/README.md
+++ b/deployments/tyk/README.md
@@ -92,6 +92,10 @@ A [Go Plugin](https://tyk.io/docs/plugins/supported-languages/golang/) is implem
 
 During the bootstrap script, the Go source in `deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go` is complied into a shared object library file (`deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.so`), which is referenced by the *Go Plugin API*. A special container is used to build the library file, using the same Go version used to build the Gateway.
 
+#### Analytics Plugin
+
+An example [analytics plugin](https://tyk.io/docs/plugins/plugin-types/analytics-plugins/) function can be found in the [example go plugin](deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go). The function is called called *MaskAnalyticsData*, and it demonstrates the analytics plugin functionality by replacing the value of the analytics `origin` with asterisks. The effect of this can be seen by sending a request to the Go Plugin API (No Auth) and viewing the corresponding analytics record in the Dashboard, where the `origin` field in the *Response* body data will be `"origin": "****"`.
+
 ### WebSockets and Server-Sent Events
 
 These examples use the *Echo Server* API Definition, which is configured to proxy to `echo-server:8080`, a simple echo server container. The echo server echoes back any message it receives, and has special endpoints which enable demonstration of WebSockets and Server-Sent Events.

--- a/deployments/tyk/README.md
+++ b/deployments/tyk/README.md
@@ -94,7 +94,7 @@ During the bootstrap script, the Go source in `deployments/tyk/volumes/tyk-gatew
 
 #### Analytics Plugin
 
-An example [analytics plugin](https://tyk.io/docs/plugins/plugin-types/analytics-plugins/) function can be found in the [example go plugin](deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go). The function is called called *MaskAnalyticsData*, and it demonstrates the analytics plugin functionality by replacing the value of the analytics `origin` with asterisks. The effect of this can be seen by sending a request to the Go Plugin API (No Auth) and viewing the corresponding analytics record in the Dashboard, where the `origin` field in the *Response* body data will be `"origin": "****"`.
+An example [analytics plugin](https://tyk.io/docs/plugins/plugin-types/analytics-plugins/) function can be found in the [example go plugin](deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go). The function is called called *MaskAnalyticsData*, and it demonstrates analytics plugin functionality by replacing the value of the `origin` field with asterisks. This effect of this can be seen by sending a request to the [Go Plugin API (No Auth)](http://tyk-gateway.localhost:8080/go-plugin-api-no-auth/get) and viewing the corresponding analytics record in the Dashboard, where the `origin` field in the *Response* body data will be `"origin": "****"`.
 
 ### WebSockets and Server-Sent Events
 

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60b4968df312ae0001e1ad0d.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60b4968df312ae0001e1ad0d.json
@@ -433,7 +433,7 @@
       "per": 0
     },
     "strip_auth_data": false,
-    "enable_detailed_recording": false,
+    "enable_detailed_recording": true,
     "graphql": {
       "enabled": false,
       "execution_mode": "proxyOnly",
@@ -462,7 +462,11 @@
         "disable_query_batching": false
       }
     },
-    "analytics_plugin": {},
+    "analytics_plugin": {
+      "enable": true,
+      "func_name": "MaskAnalyticsData",
+      "plugin_path": "plugins/go/example/example-go-plugin.so"
+    },
     "tags": []
   },
   "hook_references": [],

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
@@ -456,7 +456,7 @@
       "per": 0
     },
     "strip_auth_data": false,
-    "enable_detailed_recording": false,
+    "enable_detailed_recording": true,
     "graphql": {
       "enabled": false,
       "execution_mode": "proxyOnly",
@@ -485,7 +485,11 @@
         "disable_query_batching": false
       }
     },
-    "analytics_plugin": {},
+    "analytics_plugin": {
+      "enable": true,
+      "func_name": "MaskAnalyticsData",
+      "plugin_path": "plugins/go/example/example-go-plugin.so"
+    },
     "tags": []
   },
   "hook_references": [],

--- a/deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go
+++ b/deployments/tyk/volumes/tyk-gateway/plugins/go/example/example-go-plugin.go
@@ -196,6 +196,9 @@ func AddContextDataToResponse(rw http.ResponseWriter, res *http.Response, req *h
 	}
 }
 
+// Applies a mask to analytics data
+// This example replaces the value stored for the 'origin' field with asterisks
+// Only applies to analytics data record, the response to the client remains unchanged
 func MaskAnalyticsData(record *analytics.AnalyticsRecord) {
 	logger.Info("MaskAnalyticsData Started")
 


### PR DESCRIPTION
[Issue 188](https://github.com/TykTechnologies/tyk-demo/issues/188)

Added new analytics function which masks response data to `example-go-plugin.go` and enabled on existing `Go Plugin API` and `Go Plugin API (No Auth)`
