### PR TITLE
Added more OAS examples

### DIFF
--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-274fefb9a9a2468658c4c0895db82fb7.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-274fefb9a9a2468658c4c0895db82fb7.json
@@ -1,0 +1,158 @@
+{
+    "components": {},
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-with-cache"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2c5286341f0f820173e0",
+            "id": "274fefb9a9a2468658c4c0895db82fb7",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "operations": {
+                "anythingGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "delayGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "getGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "postPOST": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "status/{statusCode}GET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "uuidGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                }
+            }
+        },
+        "server": {
+            "listenPath": {
+                "strip": true,
+                "value": "/api-with-cache"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-2f506d14ad5c40ae6a73d172ae3224f5.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-2f506d14ad5c40ae6a73d172ae3224f5.json
@@ -1,0 +1,166 @@
+{
+    "components": {},
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-validate-request"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2cb686341f0f820173e1",
+            "id": "2f506d14ad5c40ae6a73d172ae3224f5",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "operations": {
+                "anythingGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "delayGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "validateRequest": {
+                        "enabled": true,
+                        "errorResponseCode": 422
+                    }
+                },
+                "getGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "postPOST": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "status/{statusCode}GET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "validateRequest": {
+                        "enabled": true,
+                        "errorResponseCode": 422
+                    }
+                },
+                "uuidGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                }
+            }
+        },
+        "server": {
+            "listenPath": {
+                "strip": true,
+                "value": "/api-validate-request"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-42bfdc1097144ef6413f582ca8f94f52.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-42bfdc1097144ef6413f582ca8f94f52.json
@@ -1,0 +1,222 @@
+{
+    "components": {
+        "securitySchemes": {
+            "apiKey": {
+                "in": "header",
+                "name": "api_key",
+                "type": "apiKey"
+            }
+        }
+    },
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "This is anything."
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {
+                                        "delay": 3
+                                    },
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/delay/3"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/get"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "data": {},
+                                    "files": {},
+                                    "form": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Content-Length": "0",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "json": null,
+                                    "url": "https://httpbin.org/post"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "message": "This is a custom response with status code {statusCode}"
+                                }
+                            }
+                        },
+                        "description": "Successful response with the specified status code"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "security": [
+        {
+            "apiKey": []
+        }
+    ],
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-with-cors"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2f1786341f0f820173e6",
+            "id": "42bfdc1097144ef6413f582ca8f94f52",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "global": {
+                "cors": {
+                    "allowedHeaders": [
+                        "Accept",
+                        "Content-Type",
+                        "Origin",
+                        "X-Requested-With",
+                        "Authorization"
+                    ],
+                    "allowedMethods": [
+                        "GET",
+                        "HEAD",
+                        "POST"
+                    ],
+                    "allowedOrigins": [
+                        "*"
+                    ],
+                    "enabled": true,
+                    "maxAge": 24
+                }
+            }
+        },
+        "server": {
+            "listenPath": {
+                "strip": true,
+                "value": "/api-with-cors"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-42dbc5245e87492a7ccb5a0432d37ec4.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-42dbc5245e87492a7ccb5a0432d37ec4.json
@@ -1,0 +1,264 @@
+{
+    "components": {},
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "This is anything."
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {
+                                        "delay": 3
+                                    },
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/delay/3"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/get"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "data": {},
+                                    "files": {},
+                                    "form": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Content-Length": "0",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "json": null,
+                                    "url": "https://httpbin.org/post"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "message": "This is a custom response with status code {statusCode}"
+                                }
+                            }
+                        },
+                        "description": "Successful response with the specified status code"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-with-mock-response"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2d5686341f0f820173e2",
+            "id": "42dbc5245e87492a7ccb5a0432d37ec4",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "operations": {
+                "anythingGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "enabled": true
+                        }
+                    }
+                },
+                "delayGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "enabled": true
+                        }
+                    },
+                    "validateRequest": {
+                        "enabled": true,
+                        "errorResponseCode": 422
+                    }
+                },
+                "getGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "enabled": true
+                        }
+                    }
+                },
+                "postPOST": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "enabled": true
+                        }
+                    }
+                },
+                "status/{statusCode}GET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "enabled": true
+                        }
+                    },
+                    "validateRequest": {
+                        "enabled": true,
+                        "errorResponseCode": 422
+                    }
+                },
+                "uuidGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "enabled": true
+                        }
+                    }
+                }
+            }
+        },
+        "server": {
+            "listenPath": {
+                "strip": true,
+                "value": "/api-with-mock-response"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-89f1315059bc45594e731ec3b18c8cc8.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-89f1315059bc45594e731ec3b18c8cc8.json
@@ -1,0 +1,238 @@
+{
+    "components": {
+        "securitySchemes": {
+            "apiKey": {
+                "in": "header",
+                "name": "api_key",
+                "type": "apiKey"
+            }
+        }
+    },
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "This is anything."
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {
+                                        "delay": 3
+                                    },
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/delay/3"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/get"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "data": {},
+                                    "files": {},
+                                    "form": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Content-Length": "0",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "json": null,
+                                    "url": "https://httpbin.org/post"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "message": "This is a custom response with status code {statusCode}"
+                                }
+                            }
+                        },
+                        "description": "Successful response with the specified status code"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "security": [
+        {
+            "apiKey": []
+        }
+    ],
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-with-response-body"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2f6486341f0f820173e7",
+            "id": "89f1315059bc45594e731ec3b18c8cc8",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "operations": {
+                "anythingGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "transformResponseBody": {
+                        "body": "ewogICAgImhvc3QiOiB7eyAuaGVhZGVycy5Ib3N0IH19Cn0=",
+                        "enabled": true,
+                        "format": "json"
+                    }
+                },
+                "delayGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "getGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "postPOST": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "status/{statusCode}GET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "uuidGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                }
+            }
+        },
+        "server": {
+            "listenPath": {
+                "strip": true,
+                "value": "/api-with-response-body"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-b45a8f243a6a468566b0d0ff34747c0c.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-b45a8f243a6a468566b0d0ff34747c0c.json
@@ -1,0 +1,241 @@
+{
+    "components": {
+        "securitySchemes": {
+            "apiKey": {
+                "in": "header",
+                "name": "Authrization",
+                "type": "apiKey"
+            }
+        }
+    },
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "This is anything."
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {
+                                        "delay": 3
+                                    },
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/delay/3"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/get"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "data": {},
+                                    "files": {},
+                                    "form": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Content-Length": "0",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "json": null,
+                                    "url": "https://httpbin.org/post"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "message": "This is a custom response with status code {statusCode}"
+                                }
+                            }
+                        },
+                        "description": "Successful response with the specified status code"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "security": [
+        {
+            "apiKey": []
+        }
+    ],
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-with-auth-token"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2dcf86341f0f820173e3",
+            "id": "b45a8f243a6a468566b0d0ff34747c0c",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "operations": {
+                "anythingGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "delayGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "getGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "postPOST": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "status/{statusCode}GET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                },
+                "uuidGET": {
+                    "allow": {
+                        "enabled": true
+                    }
+                }
+            }
+        },
+        "server": {
+            "authentication": {
+                "enabled": true,
+                "securitySchemes": {
+                    "apiKey": {
+                        "enabled": true
+                    }
+                }
+            },
+            "listenPath": {
+                "strip": true,
+                "value": "/api-with-auth-token"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-dcb1ae9a2d5a47cb426526f06eebafcd.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-oas-dcb1ae9a2d5a47cb426526f06eebafcd.json
@@ -1,0 +1,308 @@
+{
+    "components": {
+        "securitySchemes": {
+            "apiKey": {
+                "in": "header",
+                "name": "api_key",
+                "type": "apiKey"
+            }
+        }
+    },
+    "info": {
+        "title": "httpbin API",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "anythingGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "This is anything."
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return anything"
+            }
+        },
+        "/delay": {
+            "get": {
+                "operationId": "delayGET",
+                "parameters": [
+                    {
+                        "description": "Time to delay in seconds",
+                        "in": "query",
+                        "name": "delay",
+                        "required": true,
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {
+                                        "delay": 3
+                                    },
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/delay/3"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Delay response by a specified time"
+            }
+        },
+        "/get": {
+            "get": {
+                "operationId": "getGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "origin": "192.168.0.1",
+                                    "url": "https://httpbin.org/get"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return GET request data"
+            }
+        },
+        "/post": {
+            "post": {
+                "operationId": "postPOST",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "args": {},
+                                    "data": {},
+                                    "files": {},
+                                    "form": {},
+                                    "headers": {
+                                        "Accept": "application/json",
+                                        "Content-Length": "0",
+                                        "Host": "httpbin.org"
+                                    },
+                                    "json": null,
+                                    "url": "https://httpbin.org/post"
+                                }
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return POST request data"
+            }
+        },
+        "/status/{statusCode}": {
+            "get": {
+                "operationId": "status/{statusCode}GET",
+                "parameters": [
+                    {
+                        "description": "HTTP status code",
+                        "in": "path",
+                        "name": "statusCode",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "message": "This is a custom response with status code {statusCode}"
+                                }
+                            }
+                        },
+                        "description": "Successful response with the specified status code"
+                    }
+                },
+                "summary": "Return a response with the specified status code"
+            }
+        },
+        "/uuid": {
+            "get": {
+                "operationId": "uuidGET",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                            }
+                        },
+                        "description": "Successful response"
+                    }
+                },
+                "summary": "Return a UUID"
+            }
+        }
+    },
+    "security": [
+        {
+            "apiKey": []
+        }
+    ],
+    "servers": [
+        {
+            "url": "http://localhost:8181/api-with-multi-middleware"
+        }
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "dbId": "650c2e1c86341f0f820173e4",
+            "id": "dcb1ae9a2d5a47cb426526f06eebafcd",
+            "name": "httpbin API",
+            "orgId": "646490d486341f29c665c45c",
+            "state": {
+                "active": true
+            }
+        },
+        "middleware": {
+            "global": {
+                "cache": {
+                    "enabled": true,
+                    "timeout": 60
+                }
+            },
+            "operations": {
+                "anythingGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "code": 200,
+                            "enabled": true
+                        }
+                    }
+                },
+                "delayGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "code": 200,
+                            "contentType": "application/json",
+                            "enabled": true
+                        }
+                    },
+                    "validateRequest": {
+                        "enabled": true,
+                        "errorResponseCode": 422
+                    }
+                },
+                "getGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "code": 200,
+                            "contentType": "application/json",
+                            "enabled": true
+                        }
+                    }
+                },
+                "postPOST": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "code": 200,
+                            "contentType": "application/json",
+                            "enabled": true
+                        }
+                    }
+                },
+                "status/{statusCode}GET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "code": 200,
+                            "contentType": "application/json",
+                            "enabled": true
+                        }
+                    },
+                    "validateRequest": {
+                        "enabled": true,
+                        "errorResponseCode": 422
+                    }
+                },
+                "uuidGET": {
+                    "allow": {
+                        "enabled": true
+                    },
+                    "cache": {
+                        "cacheResponseCodes": [
+                            200
+                        ],
+                        "enabled": true,
+                        "timeout": 5
+                    },
+                    "mockResponse": {
+                        "enabled": true,
+                        "fromOASExamples": {
+                            "code": 200,
+                            "enabled": true
+                        }
+                    }
+                }
+            }
+        },
+        "server": {
+            "authentication": {
+                "enabled": true,
+                "securitySchemes": {
+                    "apiKey": {
+                        "enabled": true
+                    }
+                }
+            },
+            "listenPath": {
+                "strip": true,
+                "value": "/api-with-multi-middleware"
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin.org"
+        }
+    }
+}


### PR DESCRIPTION
Added more OAS API examples with:
- cache middleware enabled, also per endpoint
-  validate Request
- Auth token enabled
- Cors enabled
- Response body transformation
- Mock Response middleware enabled
- Client certificates added