### PR TITLE
add subscriptions deployment

### DIFF
--- a/deployments/subscriptions/Dockerfile
+++ b/deployments/subscriptions/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.21-alpine as build
+WORKDIR /build
+RUN apk update && apk upgrade
+RUN apk add git
+RUN git clone https://github.com/TykTechnologies/graphql-go-tools.git
+WORKDIR /build/graphql-go-tools/examples/chat
+RUN go mod tidy && go build -o chat ./server
+
+FROM alpine:3.18 as runner
+WORKDIR /app
+COPY --from=build /build/graphql-go-tools/examples/chat/chat ./chat
+EXPOSE 8085
+ENTRYPOINT ["./chat"]

--- a/deployments/subscriptions/README.md
+++ b/deployments/subscriptions/README.md
@@ -1,0 +1,85 @@
+# Subscriptions
+Spins up a GraphQL chat example application that can use WebSocket subscriptions.
+
+## Setup
+
+Run the `up.sh` script with the `subscriptions` parameter:
+
+```
+./up.sh subscriptions
+```
+
+### Environment variables
+
+| Variable | Description | Required | Default |
+| -------- | ----------- | -------- | ------- |
+| SUBSCRIPTIONS_CHAT_APP_PORT | Sets the external port for the chat app | No | 8093 |
+
+### Usage
+
+This deployment will create a GraphQL proxy-only API to the chat example app from `graphql-go-tools`.
+
+It is then accessible via `ws://tyk-gateway.localhost:8080/subscriptions-chat/`.
+
+As exporting postman collection does not work for WebSocket requests ([feature request](https://github.com/postmanlabs/postman-app-support/issues/11252)), you can find example messages here:
+
+#### graphql-ws
+Set the header `Sec-WebSocket-Protocol` to `graphql-ws`.
+
+##### Init
+```json
+{"type":"connection_init"}
+```
+
+##### Send query
+```json
+{"id":"1","type":"start","payload":{"query":"{ room(name:\"#my_room\") { name } }"}}
+```
+
+##### Send mutation
+```json
+{"id":"3","type":"start","payload":{"query":"mutation { post(text: \"hello\", username: \"me\", roomName: \"#my_room\") { text } }"}}
+```
+
+##### Start subscription
+```json
+{"id":"2","type":"start","payload":{"query":"subscription { messageAdded(roomName:\"#my_room\") { text } }"}}
+```
+
+##### Stop subscription
+```json
+{"id":"2","type":"stop"}
+```
+
+#### graphql-transport-ws
+Set the header `Sec-WebSocket-Protocol` to `graphql-transport-ws`.
+
+##### Init
+```json
+{"type":"connection_init"}
+```
+
+##### Send ping
+```json
+{"type":"ping","payload":"ping from client"}
+```
+
+##### Send query
+```json
+{"id":"1","type":"subscribe","payload":{"query":"{ room(name:\"#my_room\") { name } }"}}
+```
+
+##### Send mutation
+```json
+{"id":"3","type":"subscribe","payload":{"query":"mutation { post(text: \"hello\", username: \"me\", roomName: \"#my_room\") { text } }"}}
+```
+
+##### Start subscription
+```json
+{"id":"2","type":"subscribe","payload":{"query":"subscription { messageAdded(roomName:\"#my_room\") { text } }"}}
+```
+
+##### Stop subscription
+```json
+{"id":"2","type":"complete"}
+```

--- a/deployments/subscriptions/README.md
+++ b/deployments/subscriptions/README.md
@@ -21,7 +21,7 @@ This deployment will create a GraphQL proxy-only API to the chat example app fro
 
 It is then accessible via `ws://tyk-gateway.localhost:8080/subscriptions-chat/`.
 
-As exporting postman collection does not work for WebSocket requests ([feature request](https://github.com/postmanlabs/postman-app-support/issues/11252)), you can find example messages here:
+As it's currently not possible to export a Postman collection that contains WebSocket requests ([feature request](https://github.com/postmanlabs/postman-app-support/issues/11252)), to demonstrate this example you will have create the requests in Postman yourself using the following examples. Remember to use the *WebSocket* request type.
 
 #### graphql-ws
 Set the header `Sec-WebSocket-Protocol` to `graphql-ws`.

--- a/deployments/subscriptions/bootstrap.sh
+++ b/deployments/subscriptions/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+source scripts/common.sh
+deployment="Subscriptions"
+log_start_deployment
+bootstrap_progress
+
+chat_base_url="http://localhost:${SUBSCRIPTIONS_CHAT_APP_PORT:-8093}"
+
+log_message "Waiting for chat application to respond ok"
+wait_for_response "$chat_base_url" "200"
+
+dashboard_base_url="http://tyk-dashboard.localhost:$(jq -r '.listen_port' deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf)"
+gateway_base_url="http://$(jq -r '.host_config.override_hostname' deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf)"
+dashboard_admin_api_credentials=$(cat deployments/tyk/volumes/tyk-dashboard/tyk_analytics.conf | jq -r .admin_secret)
+dashboard_user_api_key=$(get_context_data "1" "dashboard-user" "1" "api-key")
+
+# Create APIs
+create_api "deployments/subscriptions/data/apis-chatapp.json" "$dashboard_admin_api_credentials" "$dashboard_user_api_key"
+bootstrap_progress
+
+log_end_deployment
+
+echo -e "\033[2K
+▼ Subscriptions
+  ▽ Chat application
+         Playground URL : $chat_base_url
+       GraphQL Endpoint : $chat_base_url/query"

--- a/deployments/subscriptions/data/apis-chatapp.json
+++ b/deployments/subscriptions/data/apis-chatapp.json
@@ -1,0 +1,490 @@
+{
+    "created_at": "2023-09-27T13:41:51Z",
+    "api_model": {},
+    "api_definition": {
+      "api_id": "f446ea99ee0a416d768bcd760d454f44",
+      "jwt_issued_at_validation_skew": 0,
+      "upstream_certificates": {},
+      "use_keyless": true,
+      "enable_coprocess_auth": false,
+      "base_identity_provided_by": "",
+      "custom_middleware": {
+        "pre": [],
+        "post": [],
+        "post_key_auth": [],
+        "auth_check": {
+          "disabled": false,
+          "name": "",
+          "path": "",
+          "require_session": false,
+          "raw_body_only": false
+        },
+        "response": [],
+        "driver": "",
+        "id_extractor": {
+          "disabled": false,
+          "extract_from": "",
+          "extract_with": "",
+          "extractor_config": {}
+        }
+      },
+      "disable_quota": false,
+      "custom_middleware_bundle": "",
+      "cache_options": {
+        "cache_timeout": 60,
+        "enable_cache": true,
+        "cache_all_safe_requests": false,
+        "cache_response_codes": [],
+        "enable_upstream_cache_control": false,
+        "cache_control_ttl_header": "",
+        "cache_by_headers": []
+      },
+      "enable_ip_blacklisting": false,
+      "tag_headers": [],
+      "jwt_scope_to_policy_mapping": {},
+      "pinned_public_keys": {},
+      "expire_analytics_after": 0,
+      "external_oauth": {
+        "enabled": false,
+        "providers": []
+      },
+      "domain": "",
+      "openid_options": {
+        "providers": [],
+        "segregate_by_client": false
+      },
+      "jwt_policy_field_name": "",
+      "enable_proxy_protocol": false,
+      "jwt_default_policies": [],
+      "active": true,
+      "jwt_expires_at_validation_skew": 0,
+      "config_data": {},
+      "notifications": {
+        "shared_secret": "",
+        "oauth_on_keychange_url": ""
+      },
+      "jwt_client_base_field": "",
+      "auth": {
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "cookie_name": "",
+        "name": "",
+        "validate_signature": false,
+        "use_param": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        },
+        "use_cookie": false,
+        "param_name": "",
+        "use_certificate": false
+      },
+      "check_host_against_uptime_tests": false,
+      "auth_provider": {
+        "name": "",
+        "storage_engine": "",
+        "meta": {}
+      },
+      "custom_plugin_auth_enabled": false,
+      "blacklisted_ips": [],
+      "graphql": {
+        "schema": "directive @user(username: String!) on SUBSCRIPTION\n\ntype Chatroom {\n  name: String!\n  messages: [Message!]!\n}\n\ntype Message {\n  id: ID!\n  text: String!\n  createdBy: String!\n  createdAt: Time!\n}\n\ntype Mutation {\n  post(text: String!, username: String!, roomName: String!): Message!\n}\n\ntype Query {\n  room(name: String!): Chatroom\n}\n\ntype Subscription {\n  messageAdded(roomName: String!): Message!\n}\n\nscalar Time",
+        "enabled": true,
+        "engine": {
+          "field_configs": [],
+          "data_sources": []
+        },
+        "type_field_configurations": [],
+        "execution_mode": "proxyOnly",
+        "proxy": {
+          "auth_headers": {},
+          "request_headers": {}
+        },
+        "subgraph": {
+          "sdl": ""
+        },
+        "supergraph": {
+          "subgraphs": [
+            {
+              "api_id": "",
+              "name": "",
+              "url": "",
+              "sdl": "",
+              "headers": {}
+            }
+          ],
+          "merged_sdl": "",
+          "global_headers": {},
+          "disable_query_batching": false
+        },
+        "version": "2",
+        "playground": {
+          "enabled": false,
+          "path": ""
+        },
+        "last_schema_update": "2023-09-27T13:41:51.762Z"
+      },
+      "hmac_allowed_clock_skew": -1,
+      "dont_set_quota_on_create": false,
+      "uptime_tests": {
+        "check_list": [],
+        "config": {
+          "expire_utime_after": 0,
+          "service_discovery": {
+            "use_discovery_service": false,
+            "query_endpoint": "",
+            "use_nested_query": false,
+            "parent_data_path": "",
+            "data_path": "",
+            "cache_timeout": 60
+          },
+          "recheck_wait": 0
+        }
+      },
+      "enable_jwt": false,
+      "do_not_track": false,
+      "name": "Subscriptions Chat",
+      "slug": "subscriptions-chat",
+      "analytics_plugin": {},
+      "oauth_meta": {
+        "allowed_access_types": [],
+        "allowed_authorize_types": [],
+        "auth_login_redirect": ""
+      },
+      "CORS": {
+        "enable": false,
+        "max_age": 24,
+        "allow_credentials": false,
+        "exposed_headers": [],
+        "allowed_headers": [
+          "Origin",
+          "Accept",
+          "Content-Type",
+          "X-Requested-With",
+          "Authorization"
+        ],
+        "options_passthrough": false,
+        "debug": false,
+        "allowed_origins": [
+          "*"
+        ],
+        "allowed_methods": [
+          "GET",
+          "POST",
+          "HEAD"
+        ]
+      },
+      "event_handlers": {
+        "events": {}
+      },
+      "proxy": {
+        "target_url": "http://subscriptions-chatapp:8085/query",
+        "service_discovery": {
+          "endpoint_returns_list": false,
+          "cache_timeout": 0,
+          "parent_data_path": "",
+          "query_endpoint": "",
+          "use_discovery_service": false,
+          "_sd_show_port_path": false,
+          "target_path": "",
+          "use_target_list": false,
+          "use_nested_query": false,
+          "cache_disabled": false,
+          "data_path": "",
+          "port_data_path": ""
+        },
+        "check_host_against_uptime_tests": false,
+        "transport": {
+          "ssl_insecure_skip_verify": false,
+          "ssl_ciphers": [],
+          "ssl_min_version": 0,
+          "ssl_max_version": 0,
+          "ssl_force_common_name_check": false,
+          "proxy_url": ""
+        },
+        "target_list": [],
+        "preserve_host_header": false,
+        "strip_listen_path": true,
+        "enable_load_balancing": false,
+        "listen_path": "/subscriptions-chat/",
+        "disable_strip_slash": true
+      },
+      "client_certificates": [],
+      "use_basic_auth": false,
+      "version_data": {
+        "not_versioned": true,
+        "default_version": "",
+        "versions": {
+          "Default": {
+            "name": "Default",
+            "expires": "",
+            "paths": {
+              "ignored": [],
+              "white_list": [],
+              "black_list": []
+            },
+            "use_extended_paths": true,
+            "extended_paths": {
+              "ignored": [],
+              "white_list": [],
+              "black_list": [],
+              "transform": [],
+              "transform_response": [],
+              "transform_jq": [],
+              "transform_jq_response": [],
+              "transform_headers": [],
+              "transform_response_headers": [],
+              "hard_timeouts": [],
+              "circuit_breakers": [],
+              "url_rewrites": [],
+              "virtual": [],
+              "size_limits": [],
+              "method_transforms": [],
+              "track_endpoints": [],
+              "do_not_track_endpoints": [],
+              "validate_json": [],
+              "internal": [],
+              "persist_graphql": []
+            },
+            "global_headers": {},
+            "global_headers_remove": [],
+            "global_response_headers": {},
+            "global_response_headers_remove": [],
+            "ignore_endpoint_case": false,
+            "global_size_limit": 0,
+            "override_target": ""
+          }
+        }
+      },
+      "jwt_scope_claim_name": "",
+      "use_standard_auth": false,
+      "session_lifetime": 0,
+      "hmac_allowed_algorithms": [],
+      "disable_rate_limit": false,
+      "definition": {
+        "enabled": false,
+        "name": "",
+        "default": "",
+        "location": "header",
+        "key": "x-api-version",
+        "strip_path": false,
+        "strip_versioning_data": false,
+        "versions": {}
+      },
+      "use_oauth2": false,
+      "jwt_source": "",
+      "jwt_signing_method": "",
+      "config_data_disabled": false,
+      "jwt_not_before_validation_skew": 0,
+      "use_go_plugin_auth": false,
+      "jwt_identity_base_field": "",
+      "allowed_ips": [],
+      "request_signing": {
+        "is_enabled": false,
+        "secret": "",
+        "key_id": "",
+        "algorithm": "",
+        "header_list": [],
+        "certificate_id": "",
+        "signature_header": ""
+      },
+      "org_id": "5e9d9544a1dcd60001d0ed20",
+      "enable_ip_whitelisting": false,
+      "global_rate_limit": {
+        "rate": 0,
+        "per": 0
+      },
+      "protocol": "",
+      "enable_context_vars": false,
+      "tags": [],
+      "basic_auth": {
+        "disable_caching": false,
+        "cache_ttl": 0,
+        "extract_from_body": false,
+        "body_user_regexp": "",
+        "body_password_regexp": ""
+      },
+      "listen_port": 0,
+      "session_provider": {
+        "name": "",
+        "storage_engine": "",
+        "meta": {}
+      },
+      "auth_configs": {
+        "authToken": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        },
+        "basic": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        },
+        "coprocess": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        },
+        "hmac": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        },
+        "jwt": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        },
+        "oauth": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        },
+        "oidc": {
+          "disable_header": false,
+          "auth_header_name": "Authorization",
+          "cookie_name": "",
+          "name": "",
+          "validate_signature": false,
+          "use_param": false,
+          "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+          },
+          "use_cookie": false,
+          "param_name": "",
+          "use_certificate": false
+        }
+      },
+      "custom_middleware_bundle_disabled": false,
+      "strip_auth_data": false,
+      "id": "6514311fe90fa40001c670df",
+      "certificates": [],
+      "enable_signature_checking": false,
+      "use_openid": false,
+      "internal": false,
+      "jwt_skip_kid": false,
+      "enable_batch_request_support": false,
+      "enable_detailed_recording": false,
+      "scopes": {
+        "jwt": {},
+        "oidc": {}
+      },
+      "response_processors": [],
+      "use_mutual_tls_auth": false
+    },
+    "hook_references": [],
+    "is_site": false,
+    "sort_by": 0,
+    "user_group_owners": [],
+    "user_owners": []
+  }

--- a/deployments/subscriptions/docker-compose.yml
+++ b/deployments/subscriptions/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  subscriptions-chatapp:
+    build: ./deployments/subscriptions
+    ports:
+      - ${SUBSCRIPTIONS_CHAT_APP_PORT:-8093}:8085
+    networks:
+      - tyk


### PR DESCRIPTION
This PR adds a GraphQL subscriptions deployment that contains an example chat application from `graphql-go-tools`.
It also automatically adds a GraphQL proxy-only API for the chat app.

As exporting WebSocket Postman collection doesn't work I had to add the instructions to the readme (until the feature is implemented in postman).