### PR TITLE
Update tyk.conf for worker gateway

### DIFF
--- a/deployments/mdcb/volumes/tyk-worker-gateway/tyk.conf
+++ b/deployments/mdcb/volumes/tyk-worker-gateway/tyk.conf
@@ -10,7 +10,7 @@
     "policy_source": "rpc",
     "policy_record_name": "tyk_policies"
   },
-  "use_db_app_configs": true,
+  "use_db_app_configs": false,
   "db_app_conf_options": {
     "connection_string": "http://tyk-dashboard:3000",
     "node_is_segmented": false,


### PR DESCRIPTION
The worker gateway for MDCB setups has TYK_GW_USEDBAPPCONFIGS config set to true, which is a misconfiguration https://tyk.io/docs/tyk-oss-gateway/configuration/#use_db_app_configs