### PR TITLE
Setting elasticsearch pump configuration value extended_stats to true.

### DIFF
--- a/deployments/analytics-kibana/volumes/tyk-pump/pump-elasticsearch.conf
+++ b/deployments/analytics-kibana/volumes/tyk-pump/pump-elasticsearch.conf
@@ -52,7 +52,7 @@
         "enable_sniffing": false,
         "document_type": "tyk_analytics",
         "rolling_index": false,
-        "extended_stats": false,
+        "extended_stats": true,
         "version": "6",
         "bulk_config": {
           "workers": 2,


### PR DESCRIPTION
Configuring extended_stats to true in order to capture raw request and raw response in elastic. 