### PR TITLE
MDCB deployment visibility

### DIFF
--- a/deployments/mdcb/docker-compose.yml
+++ b/deployments/mdcb/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.3'
 services:
   tyk-mdcb:
     image: tykio/tyk-mdcb-docker:${MDCB_VERSION:-v2.4.0}
+    ports:
+      - 9091:9091
     networks:
       - tyk
     volumes:

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead711f5759610001818678.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead711f5759610001818678.json
@@ -299,7 +299,7 @@
               "api_model": {},
               "event_timeout": 60,
               "header_map": {},
-              "id": "649d3621c1da160001f3f2e1",
+              "id": "65687b7aaedc3d0001953a3d",
               "method": "POST",
               "name": "Webhook Receiver Post",
               "org_id": "5e9d9544a1dcd60001d0ed20",
@@ -354,11 +354,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -371,7 +375,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [
     {
@@ -379,7 +384,7 @@
       "event_timeout": 60,
       "hook": {
         "api_model": {},
-        "id": "649d3621c1da160001f3f2e1",
+        "id": "65687b7aaedc3d0001953a3d",
         "org_id": "5e9d9544a1dcd60001d0ed20",
         "name": "Webhook Receiver Post",
         "method": "POST",

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead711f5759610001818679.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead711f5759610001818679.json
@@ -323,11 +323,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -342,7 +346,8 @@
     "analytics_plugin": {},
     "tags": [
       "tyk-gateway-2"
-    ]
+    ],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead711f575961000181867a.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead711f575961000181867a.json
@@ -647,11 +647,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -666,7 +670,8 @@
     "analytics_plugin": {},
     "tags": [
       "tyk-gateway-2"
-    ]
+    ],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead7120575961000181867b.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead7120575961000181867b.json
@@ -339,11 +339,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -356,7 +360,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead7120575961000181867c.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead7120575961000181867c.json
@@ -321,11 +321,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -338,7 +342,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead7120575961000181867d.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead7120575961000181867d.json
@@ -326,11 +326,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -343,7 +347,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead727f5759610001818687.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ead727f5759610001818687.json
@@ -330,11 +330,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -347,7 +351,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5eb6346743f0440001373f5b.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5eb6346743f0440001373f5b.json
@@ -426,11 +426,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -443,7 +447,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ebcad27bcec140001bca92d.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ebcad27bcec140001bca92d.json
@@ -429,11 +429,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -446,7 +450,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5ebd51f8ad691100014b4c6f.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5ebd51f8ad691100014b4c6f.json
@@ -440,11 +440,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -457,7 +461,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5eed929be9e7a6000127a6d9.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5eed929be9e7a6000127a6d9.json
@@ -426,11 +426,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -443,7 +447,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5efa93c4f7502d0001cf4a1a.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5efa93c4f7502d0001cf4a1a.json
@@ -434,11 +434,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -454,7 +458,8 @@
     "tags": [
       "cluster1",
       "cluster2"
-    ]
+    ],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5f339452522d9f00019d0046.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5f339452522d9f00019d0046.json
@@ -426,11 +426,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -443,7 +447,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5f535c7e74cbbf00019db1fd.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5f535c7e74cbbf00019db1fd.json
@@ -426,11 +426,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -443,7 +447,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5f535c8c74cbbf00019db1fe.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5f535c8c74cbbf00019db1fe.json
@@ -426,11 +426,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -443,7 +447,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-5fdacb0281a4960001064139.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-5fdacb0281a4960001064139.json
@@ -438,11 +438,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -455,7 +459,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-6024c601afd3d900011f60c9.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-6024c601afd3d900011f60c9.json
@@ -438,11 +438,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -455,7 +459,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-609a1bdf8756d10001351aa9.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-609a1bdf8756d10001351aa9.json
@@ -440,11 +440,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -457,7 +461,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60b4968df312ae0001e1ad0d.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60b4968df312ae0001e1ad0d.json
@@ -446,11 +446,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -464,10 +468,11 @@
     },
     "analytics_plugin": {
       "enable": true,
-      "func_name": "MaskAnalyticsData",
-      "plugin_path": "plugins/go/example/example-go-plugin.so"
+      "plugin_path": "plugins/go/example/example-go-plugin.so",
+      "func_name": "MaskAnalyticsData"
     },
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60b8d132cd45340001bec761.json
@@ -469,11 +469,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -487,10 +491,11 @@
     },
     "analytics_plugin": {
       "enable": true,
-      "func_name": "MaskAnalyticsData",
-      "plugin_path": "plugins/go/example/example-go-plugin.so"
+      "plugin_path": "plugins/go/example/example-go-plugin.so",
+      "func_name": "MaskAnalyticsData"
     },
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-60d42ddacf741c00019727d9.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-60d42ddacf741c00019727d9.json
@@ -446,11 +446,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -463,7 +467,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-610a838a03ca38000122e111.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-610a838a03ca38000122e111.json
@@ -438,11 +438,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -455,7 +459,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-615172e48852f00001522ed5.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-615172e48852f00001522ed5.json
@@ -462,11 +462,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -479,7 +483,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-615175ee8852f00001522ed6.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-615175ee8852f00001522ed6.json
@@ -461,11 +461,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -478,7 +482,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-615d2dbd8bf3980001c7c6c1.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-615d2dbd8bf3980001c7c6c1.json
@@ -446,11 +446,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -463,7 +467,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-61946f3536dbb90001b7aed5.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-61946f3536dbb90001b7aed5.json
@@ -488,11 +488,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -505,7 +509,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-619471e736dbb90001b7aed6.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-619471e736dbb90001b7aed6.json
@@ -440,11 +440,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -457,7 +461,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-619472b536dbb90001b7aed7.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-619472b536dbb90001b7aed7.json
@@ -440,11 +440,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -457,7 +461,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-61c406297333700001d15861.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-61c406297333700001d15861.json
@@ -496,11 +496,15 @@
               "default_type_name": "Int"
             }
           }
-        ]
+        ],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -513,7 +517,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-61ca28234d94310001957b4d.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-61ca28234d94310001957b4d.json
@@ -446,11 +446,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -463,7 +467,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-61d89590fb3c3800017895ee.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-61d89590fb3c3800017895ee.json
@@ -456,11 +456,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -473,7 +477,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-61d895fdfb3c3800017895ef.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-61d895fdfb3c3800017895ef.json
@@ -523,11 +523,15 @@
               "default_type_name": "User"
             }
           }
-        ]
+        ],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -540,7 +544,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-620e87e0fcade600016df5f9.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-620e87e0fcade600016df5f9.json
@@ -479,11 +479,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -496,7 +500,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-6225a1b137d93600015a1731.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-6225a1b137d93600015a1731.json
@@ -594,11 +594,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -611,7 +615,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-62a0ec2592faf50001395816.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-62a0ec2592faf50001395816.json
@@ -379,11 +379,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -396,7 +400,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-641c14bf0fffb800010197bc.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-641c14bf0fffb800010197bc.json
@@ -438,11 +438,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -455,7 +459,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-641c14ce0fffb800010197bd.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-641c14ce0fffb800010197bd.json
@@ -438,11 +438,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -455,7 +459,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-641c14e80fffb800010197be.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-641c14e80fffb800010197be.json
@@ -454,11 +454,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -471,7 +475,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-65686ca0f57de80001acf0c6.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-65686ca0f57de80001acf0c6.json
@@ -1,0 +1,470 @@
+{
+  "created_at": "2023-11-30T11:06:08Z",
+  "api_model": {},
+  "api_definition": {
+    "id": "65686ca0f57de80001acf0c6",
+    "name": "External HTTPbin",
+    "slug": "external-httpbin",
+    "listen_port": 0,
+    "protocol": "",
+    "enable_proxy_protocol": false,
+    "api_id": "627efb71ebae49df7a853b9769b65fce",
+    "org_id": "5e9d9544a1dcd60001d0ed20",
+    "use_keyless": false,
+    "use_oauth2": false,
+    "external_oauth": {
+      "enabled": false,
+      "providers": []
+    },
+    "use_openid": false,
+    "openid_options": {
+      "providers": [],
+      "segregate_by_client": false
+    },
+    "oauth_meta": {
+      "allowed_access_types": [],
+      "allowed_authorize_types": [],
+      "auth_login_redirect": ""
+    },
+    "auth": {
+      "name": "",
+      "use_param": false,
+      "param_name": "",
+      "use_cookie": false,
+      "cookie_name": "",
+      "disable_header": false,
+      "auth_header_name": "Authorization",
+      "use_certificate": false,
+      "validate_signature": false,
+      "signature": {
+        "algorithm": "",
+        "header": "",
+        "use_param": false,
+        "param_name": "",
+        "secret": "",
+        "allowed_clock_skew": 0,
+        "error_code": 0,
+        "error_message": ""
+      }
+    },
+    "auth_configs": {
+      "authToken": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      },
+      "basic": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      },
+      "coprocess": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      },
+      "hmac": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      },
+      "jwt": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      },
+      "oauth": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      },
+      "oidc": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+          "algorithm": "",
+          "header": "",
+          "use_param": false,
+          "param_name": "",
+          "secret": "",
+          "allowed_clock_skew": 0,
+          "error_code": 0,
+          "error_message": ""
+        }
+      }
+    },
+    "use_basic_auth": false,
+    "basic_auth": {
+      "disable_caching": false,
+      "cache_ttl": 0,
+      "extract_from_body": false,
+      "body_user_regexp": "",
+      "body_password_regexp": ""
+    },
+    "use_mutual_tls_auth": false,
+    "client_certificates": [],
+    "upstream_certificates": {},
+    "pinned_public_keys": {},
+    "enable_jwt": false,
+    "use_standard_auth": true,
+    "use_go_plugin_auth": false,
+    "enable_coprocess_auth": false,
+    "custom_plugin_auth_enabled": false,
+    "jwt_signing_method": "",
+    "jwt_source": "",
+    "jwt_identity_base_field": "",
+    "jwt_client_base_field": "",
+    "jwt_policy_field_name": "",
+    "jwt_default_policies": [],
+    "jwt_issued_at_validation_skew": 0,
+    "jwt_expires_at_validation_skew": 0,
+    "jwt_not_before_validation_skew": 0,
+    "jwt_skip_kid": false,
+    "scopes": {
+      "jwt": {},
+      "oidc": {}
+    },
+    "jwt_scope_to_policy_mapping": {},
+    "jwt_scope_claim_name": "",
+    "notifications": {
+      "shared_secret": "",
+      "oauth_on_keychange_url": ""
+    },
+    "enable_signature_checking": false,
+    "hmac_allowed_clock_skew": -1,
+    "hmac_allowed_algorithms": [],
+    "request_signing": {
+      "is_enabled": false,
+      "secret": "",
+      "key_id": "",
+      "algorithm": "",
+      "header_list": [],
+      "certificate_id": "",
+      "signature_header": ""
+    },
+    "base_identity_provided_by": "",
+    "definition": {
+      "enabled": false,
+      "name": "",
+      "default": "",
+      "location": "header",
+      "key": "x-api-version",
+      "strip_path": false,
+      "strip_versioning_data": false,
+      "versions": {}
+    },
+    "version_data": {
+      "not_versioned": true,
+      "default_version": "",
+      "versions": {
+        "Default": {
+          "name": "Default",
+          "expires": "",
+          "paths": {
+            "ignored": [],
+            "white_list": [],
+            "black_list": []
+          },
+          "use_extended_paths": true,
+          "extended_paths": {
+            "persist_graphql": []
+          },
+          "global_headers": {},
+          "global_headers_remove": [],
+          "global_response_headers": {},
+          "global_response_headers_remove": [],
+          "ignore_endpoint_case": false,
+          "global_size_limit": 0,
+          "override_target": ""
+        }
+      }
+    },
+    "uptime_tests": {
+      "check_list": [],
+      "config": {
+        "expire_utime_after": 0,
+        "service_discovery": {
+          "use_discovery_service": false,
+          "query_endpoint": "",
+          "use_nested_query": false,
+          "parent_data_path": "",
+          "data_path": "",
+          "port_data_path": "",
+          "target_path": "",
+          "use_target_list": false,
+          "cache_disabled": false,
+          "cache_timeout": 60,
+          "endpoint_returns_list": false
+        },
+        "recheck_wait": 0
+      }
+    },
+    "proxy": {
+      "preserve_host_header": false,
+      "listen_path": "/external-httpbin/",
+      "target_url": "http://httpbin.org/",
+      "disable_strip_slash": true,
+      "strip_listen_path": true,
+      "enable_load_balancing": false,
+      "target_list": [],
+      "check_host_against_uptime_tests": false,
+      "service_discovery": {
+        "use_discovery_service": false,
+        "query_endpoint": "",
+        "use_nested_query": false,
+        "parent_data_path": "",
+        "data_path": "",
+        "port_data_path": "",
+        "target_path": "",
+        "use_target_list": false,
+        "cache_disabled": false,
+        "cache_timeout": 0,
+        "endpoint_returns_list": false
+      },
+      "transport": {
+        "ssl_insecure_skip_verify": false,
+        "ssl_ciphers": [],
+        "ssl_min_version": 0,
+        "ssl_max_version": 0,
+        "ssl_force_common_name_check": false,
+        "proxy_url": ""
+      }
+    },
+    "disable_rate_limit": false,
+    "disable_quota": false,
+    "custom_middleware": {
+      "pre": [],
+      "post": [],
+      "post_key_auth": [],
+      "auth_check": {
+        "disabled": false,
+        "name": "",
+        "path": "",
+        "require_session": false,
+        "raw_body_only": false
+      },
+      "response": [],
+      "driver": "",
+      "id_extractor": {
+        "disabled": false,
+        "extract_from": "",
+        "extract_with": "",
+        "extractor_config": {}
+      }
+    },
+    "custom_middleware_bundle": "",
+    "custom_middleware_bundle_disabled": false,
+    "cache_options": {
+      "cache_timeout": 60,
+      "enable_cache": true,
+      "cache_all_safe_requests": false,
+      "cache_response_codes": [],
+      "enable_upstream_cache_control": false,
+      "cache_control_ttl_header": "",
+      "cache_by_headers": []
+    },
+    "session_lifetime": 0,
+    "active": true,
+    "internal": false,
+    "auth_provider": {
+      "name": "",
+      "storage_engine": "",
+      "meta": {}
+    },
+    "session_provider": {
+      "name": "",
+      "storage_engine": "",
+      "meta": {}
+    },
+    "event_handlers": {
+      "events": {}
+    },
+    "enable_batch_request_support": false,
+    "enable_ip_whitelisting": false,
+    "allowed_ips": [],
+    "enable_ip_blacklisting": false,
+    "blacklisted_ips": [],
+    "dont_set_quota_on_create": false,
+    "expire_analytics_after": 0,
+    "response_processors": [],
+    "CORS": {
+      "enable": false,
+      "allowed_origins": [
+        "*"
+      ],
+      "allowed_methods": [
+        "GET",
+        "POST",
+        "HEAD"
+      ],
+      "allowed_headers": [
+        "Origin",
+        "Accept",
+        "Content-Type",
+        "X-Requested-With",
+        "Authorization"
+      ],
+      "exposed_headers": [],
+      "allow_credentials": false,
+      "max_age": 24,
+      "options_passthrough": false,
+      "debug": false
+    },
+    "domain": "",
+    "certificates": [],
+    "do_not_track": false,
+    "enable_context_vars": false,
+    "config_data": {},
+    "config_data_disabled": false,
+    "tag_headers": [],
+    "global_rate_limit": {
+      "rate": 0,
+      "per": 0
+    },
+    "strip_auth_data": false,
+    "enable_detailed_recording": false,
+    "graphql": {
+      "enabled": false,
+      "execution_mode": "proxyOnly",
+      "version": "2",
+      "schema": "",
+      "type_field_configurations": [],
+      "playground": {
+        "enabled": false,
+        "path": ""
+      },
+      "engine": {
+        "field_configs": [],
+        "data_sources": [],
+        "global_headers": []
+      },
+      "proxy": {
+        "auth_headers": {},
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
+      },
+      "subgraph": {
+        "sdl": ""
+      },
+      "supergraph": {
+        "subgraphs": [],
+        "merged_sdl": "",
+        "global_headers": {},
+        "disable_query_batching": false
+      }
+    },
+    "analytics_plugin": {},
+    "tags": [],
+    "detailed_tracing": false
+  },
+  "hook_references": [],
+  "is_site": false,
+  "sort_by": 0,
+  "user_group_owners": [],
+  "user_owners": []
+}

--- a/deployments/tyk/data/tyk-dashboard/1/policies/policy-5ead7120575961000181867f.json
+++ b/deployments/tyk/data/tyk-dashboard/1/policies/policy-5ead7120575961000181867f.json
@@ -1,6 +1,6 @@
 {
   "auth_type": "other",
-  "auth_types": null,
+  "auth_types": [],
   "state": "active",
   "access_rights_array": [],
   "graphql_enabled": false,

--- a/deployments/tyk/data/tyk-dashboard/1/policies/policy-5ead71205759610001818680.json
+++ b/deployments/tyk/data/tyk-dashboard/1/policies/policy-5ead71205759610001818680.json
@@ -1,6 +1,6 @@
 {
   "auth_type": "other",
-  "auth_types": null,
+  "auth_types": [],
   "state": "active",
   "access_rights_array": [],
   "graphql_enabled": false,

--- a/deployments/tyk/data/tyk-dashboard/1/policies/policy-5ead71205759610001818681.json
+++ b/deployments/tyk/data/tyk-dashboard/1/policies/policy-5ead71205759610001818681.json
@@ -1,6 +1,6 @@
 {
   "auth_type": "other",
-  "auth_types": null,
+  "auth_types": [],
   "state": "active",
   "access_rights_array": [],
   "graphql_enabled": false,

--- a/deployments/tyk/data/tyk-dashboard/2/apis/api-5f51f0991339530001ad60a1.json
+++ b/deployments/tyk/data/tyk-dashboard/2/apis/api-5f51f0991339530001ad60a1.json
@@ -433,11 +433,15 @@
       },
       "engine": {
         "field_configs": [],
-        "data_sources": []
+        "data_sources": [],
+        "global_headers": []
       },
       "proxy": {
         "auth_headers": {},
-        "request_headers": {}
+        "request_headers": {},
+        "use_response_extensions": {
+          "on_error_forwarding": false
+        }
       },
       "subgraph": {
         "sdl": ""
@@ -450,7 +454,8 @@
       }
     },
     "analytics_plugin": {},
-    "tags": []
+    "tags": [],
+    "detailed_tracing": false
   },
   "hook_references": [],
   "is_site": false,

--- a/deployments/tyk/data/tyk-gateway/keys/bearer-token/bearer-token-9-external_httpbin_key.json
+++ b/deployments/tyk/data/tyk-gateway/keys/bearer-token/bearer-token-9-external_httpbin_key.json
@@ -1,0 +1,24 @@
+{
+	"last_check": 0,
+	"allowance": 1000,
+	"rate": 1000,
+	"per": 60,
+	"throttle_interval": -1,
+	"throttle_retry_limit": -1,
+	"expires": 0,
+	"quota_max": -1,
+	"quota_renews": 1587524070,
+	"quota_remaining": -1,
+	"quota_renewal_rate": -1,
+	"access_rights": {
+		"627efb71ebae49df7a853b9769b65fce": {
+			"api_name": "Extenal HTTPbin",
+			"api_id": "627efb71ebae49df7a853b9769b65fce",
+			"versions": ["Default"],
+			"allowed_urls": [],
+			"limit": null,
+			"allowance_scope": ""
+		}
+	},
+	"org_id": "5e9d9544a1dcd60001d0ed20"
+}


### PR DESCRIPTION
Purpose of this PR is to made the MDCB port available to localhost, to enable externally run gateways to be able to connect into the Tyk Demo deployment as _worker gateways_.  The purpose of this is to enable local worker gateways to be run and debugged against the Tyk Demo environment.
In addition, there are also numerous updates to the data files based on updates schemas.

### MDCB update

This adds an API called _External HTTPbin_ that uses the internet-hosted `http://httpbin.org` as the target, rather than the one found within the docker network `http://httpbin`. This provides gateways running outside of the docker network with an API that they are able to proxy to , as the majority of other APIs will are targeting hostnames which only resolve within the docker network.

There is also a custom key called `external_httpbin_key` that provides access to this API. It can be used as follows (assuming local gateway is running on port `9999`):

```
curl localhost:9999/external-httpbin/get -H 'Authorization: external_httpbin_key'
{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Accept-Encoding": "gzip",
    "Authorization": "auth_key_copy",
    "Host": "httpbin.org",
    "User-Agent": "curl/8.1.2",
    "X-Amzn-Trace-Id": "Root=1-6568959e-1374c3702b9a979575323404"
  },
  "origin": "127.0.0.1, 213.55.240.159",
  "url": "http://httpbin.org/get"
}
```