### PR TITLE
Adding deprecation notice for OpenTracing

### DIFF
--- a/deployments/tracing/README.md
+++ b/deployments/tracing/README.md
@@ -1,3 +1,8 @@
+WARNING: OpenTracing support in Tyk has been deprecated in favor of OpenTelemetry. This deployment will be removed in a future release. 
+
+OpenTelemetry documentaiton: https://tyk.io/docs/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/open-telemetry-overview/
+
+
 # Zipkin
 
 Zipkin can demonstrate open tracing. It has a [Dashboard](http://localhost:9411) you can use to view traces.

--- a/deployments/tracing/bootstrap.sh
+++ b/deployments/tracing/bootstrap.sh
@@ -13,6 +13,9 @@ wait_for_response "$zipkin_base_url" "200"
 log_end_deployment
 
 echo -e "\033[2K
+WARNING: OpenTracing support has been deprecated in favor of OpenTelemetry. This deployment will be removed in a future release."
+
+echo -e "\033[2K
 ▼ Tracing
   ▽ Zipkin
                     URL : $zipkin_base_url"


### PR DESCRIPTION
as our OpenTracing support is deprecated and will be removed at some point, I have added an information to the OpenTracing/zipkin deployment. We don't need to update zipkin deployment with OpenTelemetry as Jaeger has become the most favourite open source tool for distributed tracing. 