### PR TITLE
Deprecate docker compose v1 support

### DIFF
--- a/deployments/cicd/scripts/dump-gitea.sh
+++ b/deployments/cicd/scripts/dump-gitea.sh
@@ -5,8 +5,6 @@ source scripts/common.sh
 # generates a Gitea archive dump of the configuration and repositories
 # then copies the file from the container and overwrites the tracked archive in this repo
 
-check_docker_compose_version
-
 eval "$(generate_docker_compose_command) exec -d -u git gitea sh -c \"cd /data/gitea; rm gitea-dump.zip; gitea dump -c /data/gitea/conf/app.ini --f gitea-dump.zip\""
 
 docker cp $(get_service_container_id gitea):/data/gitea/gitea-dump.zip deployments/cicd/volumes/gitea/gitea-dump.zip

--- a/deployments/mdcb/scripts/start-mdcb.sh
+++ b/deployments/mdcb/scripts/start-mdcb.sh
@@ -2,6 +2,4 @@
 
 source scripts/common.sh
 
-check_docker_compose_version
-
 eval $(generate_docker_compose_command) start tyk-mdcb

--- a/deployments/mdcb/scripts/stop-mdcb.sh
+++ b/deployments/mdcb/scripts/stop-mdcb.sh
@@ -2,6 +2,4 @@
 
 source scripts/common.sh
 
-check_docker_compose_version
-
 eval $(generate_docker_compose_command) stop tyk-mdcb

--- a/docker-compose-command.sh
+++ b/docker-compose-command.sh
@@ -2,9 +2,6 @@
 
 source scripts/common.sh
 
-# check if docker compose version is v1.x
-check_docker_compose_version
-
 docker_compose_command="$(generate_docker_compose_command) $@"
 
 echo "Running command: $docker_compose_command"

--- a/down.sh
+++ b/down.sh
@@ -4,9 +4,6 @@ source scripts/common.sh
 
 echo "Bringing Tyk Demo deployment DOWN"
 
-# check if docker compose version is v1.x
-check_docker_compose_version
-
 # check if deployments exist
 if [[ -s .bootstrap/bootstrapped_deployments ]]; then
   # display deployments to be removed

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -212,24 +212,9 @@ get_service_image_tag () {
   echo $(get_service_container_data $1 "{{ .Config.Image }}" | awk -F':' '{print $2}')
 }
 
-check_docker_compose_version () {
-  rm .bootstrap/is_docker_compose_v1 2> /dev/null
-  regex_docker_compose_version_1='^docker-compose version 1\.'
-  if [[ $(docker-compose --version) =~ $regex_docker_compose_version_1 ]]; then
-    echo "Detected Docker Compose v1"
-    touch .bootstrap/is_docker_compose_v1
-  fi
-}
-
 generate_docker_compose_command () {
   # create the docker compose command
-  command_docker_compose=""
-  # use "docker-compose" if version is 1, otherwise use "docker compose"
-  if [ -f .bootstrap/is_docker_compose_v1 ]; then
-    command_docker_compose="docker-compose"
-  else
-    command_docker_compose="docker compose --env-file `pwd`/.env"
-  fi
+  command_docker_compose="docker compose --env-file `pwd`/.env"
   while read deployment; do
     command_docker_compose="$command_docker_compose -f deployments/$deployment/docker-compose.yml"
   done < .bootstrap/bootstrapped_deployments

--- a/up.sh
+++ b/up.sh
@@ -39,9 +39,6 @@ mkdir -p .bootstrap 1> /dev/null
 # make the logs directory
 mkdir -p logs 1> /dev/null
 
-# check if docker compose version is v1.x
-check_docker_compose_version
-
 # ensure Docker environment variables are correctly set before creating containers
 # these allow for specialised deployments to be easily used, without having to manually set the environment variables
 # this approach aims to avoid misconfiguration and issues related to that

--- a/up.sh
+++ b/up.sh
@@ -142,6 +142,9 @@ if [ "$persist_log" = false ]; then
   # test.log file is not cleared, as it is responsibilty of the test scripts
 fi
 
+# log docker compose version
+log_message "$(docker compose version)"
+
 # bring the containers up
 command_docker_compose="$(generate_docker_compose_command) up --quiet-pull --remove-orphans -d"
 echo "Running docker compose command: $command_docker_compose"

--- a/up.sh
+++ b/up.sh
@@ -143,7 +143,7 @@ if [ "$persist_log" = false ]; then
 fi
 
 # bring the containers up
-command_docker_compose="$(generate_docker_compose_command) up --remove-orphans -d"
+command_docker_compose="$(generate_docker_compose_command) up --quiet-pull --remove-orphans -d"
 echo "Running docker compose command: $command_docker_compose"
 eval $command_docker_compose
 if [ "$?" != 0 ]; then


### PR DESCRIPTION
This resolves a problem with usage of the legacy `docker-compose` command. It's now time to force usage of `docker compose` instead.