### PR TITLE
Improve license expiry error reporting

### DIFF
--- a/deployments/mdcb/bootstrap.sh
+++ b/deployments/mdcb/bootstrap.sh
@@ -24,9 +24,9 @@ bootstrap_progress
 # check the MDCB licence expiry
 log_message "Checking MDCB licence expiry"
 licence_days_remaining=0
-check_licence_expiry "MDCB_LICENCE"
-if [[ "$?" -eq "1" ]]; then
-  echo "ERROR: Tyk MDCB licence has expired. Update MDCB_LICENCE variable in .env file with a new licence."
+check_licence_expiry "MDCB_LICENCE"; expiry_check=$?
+if [[ "$expiry_check" -eq "1" ]]; then
+  # The error message is now displayed by the check_licence_expiry function itself
   exit 1
 fi
 mdcb_licence_days_remaining=$licence_days_remaining

--- a/deployments/tyk/bootstrap.sh
+++ b/deployments/tyk/bootstrap.sh
@@ -30,9 +30,9 @@ bootstrap_progress
 
 log_message "Checking Dashboard licence expiry"
 licence_days_remaining=0
-check_licence_expiry "DASHBOARD_LICENCE"
-if [[ "$?" -eq "1" ]]; then
-  log_message "ERROR: Tyk Dashboard licence has expired. Update DASHBOARD_LICENCE variable in .env file with a new licence."
+check_licence_expiry "DASHBOARD_LICENCE"; expiry_check=$?
+if [[ "$expiry_check" -eq "1" ]]; then
+  # The error message is now displayed by the check_licence_expiry function itself
   exit 1
 fi
 dashboard_licence_days_remaining=$licence_days_remaining
@@ -83,8 +83,8 @@ done
 log_message "OpenSSL version used for generating certs: $(docker exec $OPENSSL_CONTAINER_NAME openssl version)"
 
 log_message "Generating self-signed certificate for TLS connections to tyk-gateway-2.localhost"
-docker exec $OPENSSL_CONTAINER_NAME sh -c "openssl req -x509 -newkey rsa:4096 -subj \"/CN=tyk-gateway-2.localhost\" -keyout /tyk-gateway-certs/tls-private-key.pem -out /tyk-gateway-certs/tls-certificate.pem -days 365 -nodes" >/dev/null 2>&1
-if [ "$?" -ne "0" ]; then
+docker exec $OPENSSL_CONTAINER_NAME sh -c "openssl req -x509 -newkey rsa:4096 -subj \"/CN=tyk-gateway-2.localhost\" -keyout /tyk-gateway-certs/tls-private-key.pem -out /tyk-gateway-certs/tls-certificate.pem -days 365 -nodes" >/dev/null 2>&1; openssl_cmd_status=$?
+if [ "$openssl_cmd_status" -ne "0" ]; then
   echo "ERROR: Could not generate self-signed certificate"
   exit 1
 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -326,6 +326,13 @@ check_licence_expiry () {
   # check if licence time remaining (in seconds) is less or equal to 0
   if [ "$licence_seconds_remaining" -le "0" ]; then
     log_message "  ERROR: Licence $1 has expired"
+    if [[ "$1" == "DASHBOARD_LICENCE" ]]; then
+      echo "ERROR: Tyk Dashboard licence has expired. Update DASHBOARD_LICENCE variable in .env file with a new licence."
+    elif [[ "$1" == "MDCB_LICENCE" ]]; then
+      echo "ERROR: Tyk MDCB licence has expired. Update MDCB_LICENCE variable in .env file with a new licence."
+    else
+      echo "ERROR: Licence $1 has expired."
+    fi
     return 1; # does not meet requirements
   else
     if [[ "$licence_days_remaining" -le "7" ]]; then

--- a/up.sh
+++ b/up.sh
@@ -211,17 +211,18 @@ log_message "$(docker compose version)"
 # bring the containers up
 command_docker_compose="$(generate_docker_compose_command) up --quiet-pull --remove-orphans -d"
 echo "Running docker compose command: $command_docker_compose"
-eval $command_docker_compose
-if [ "$?" != 0 ]; then
+eval $command_docker_compose; command_exit_code=$?
+if [ "$command_exit_code" != 0 ]; then
   echo "Error occurred when using Docker Compose to bring containers up"
   exit 1
 fi
 
 # bootstrap the deployments
 for deployment in "${deployments_to_create[@]}"; do
-  eval "deployments/$deployment/bootstrap.sh"
-  if [ "$?" != 0 ]; then
+  eval "deployments/$deployment/bootstrap.sh"; bootstrap_exit_code=$?
+  if [ "$bootstrap_exit_code" != 0 ]; then
     capture_container_logs $deployment
+    # Generic error message for other issues
     echo "Error occurred during bootstrap of $deployment, when running deployments/$deployment/bootstrap.sh"
     echo "Log files can be found in the the logs directory"
     exit 1


### PR DESCRIPTION
- Centralize license expiry error messages in `check_licence_expiry` function
- Add a specific message for MDCB license expiry
- Remove duplicate error messages from bootstrap scripts
- Use a safer command execution pattern for exit code capture (get exit code from `$?` in the same line of the execution)
