### PR TITLE
fix cors on gql in dev portal

### DIFF
--- a/deployments/tyk/data/tyk-dashboard/1/apis/api-8ba9f26729e041a95f84f01dd0ce6d9b.json
+++ b/deployments/tyk/data/tyk-dashboard/1/apis/api-8ba9f26729e041a95f84f01dd0ce6d9b.json
@@ -403,8 +403,12 @@
         "http://localhost:3100"
       ],
       "allowed_methods": [],
-      "allowed_headers": [],
-      "exposed_headers": [],
+      "exposed_headers": [
+        "*"
+      ],
+      "allowed_headers": [
+        "*"
+      ],
       "allow_credentials": true,
       "max_age": 24,
       "options_passthrough": true,


### PR DESCRIPTION
fix cors on gql in dev portal.  without these configs on the api def, the gql portal fails to fetch the schema from gql through tyk