### PR TITLE
Add gateway node/group filtering to dashboards and fix MDCB segmentation

### DIFF
--- a/deployments/mdcb/bootstrap.sh
+++ b/deployments/mdcb/bootstrap.sh
@@ -63,6 +63,23 @@ else
   set_docker_environment_value "NGROK_MDCB_TUNNEL_URL" "$ngrok_mdcb_tunnel_url"
 fi
 
+# set node_is_segmented based on whether gateway tags are configured
+log_message "Setting node segmentation flags based on gateway tags"
+gateway_worker_tags=$(grep "^GATEWAY_WORKER_TAGS=" .env 2>/dev/null | cut -d'=' -f2-)
+if [ -n "$gateway_worker_tags" ]; then
+  set_docker_environment_value "GATEWAY_WORKER_NODE_IS_SEGMENTED" "true"
+else
+  set_docker_environment_value "GATEWAY_WORKER_NODE_IS_SEGMENTED" "false"
+fi
+gateway_worker_ngrok_tags=$(grep "^GATEWAY_WORKER_NGROK_TAGS=" .env 2>/dev/null | cut -d'=' -f2-)
+if [ -n "$gateway_worker_ngrok_tags" ]; then
+  set_docker_environment_value "GATEWAY_WORKER_NGROK_NODE_IS_SEGMENTED" "true"
+else
+  set_docker_environment_value "GATEWAY_WORKER_NGROK_NODE_IS_SEGMENTED" "false"
+fi
+log_ok
+bootstrap_progress
+
 # recreate containers to use updated environment variables
 log_message "Recreating MDCB deployment containers, so that they use updated MDCB user API credentials (tyk-mdcb, tyk-worker-gateway tyk-worker-gateway-ngrok)"
 eval $(generate_docker_compose_command) up -d --no-deps --force-recreate tyk-mdcb tyk-worker-gateway tyk-worker-gateway-ngrok 2> /dev/null

--- a/deployments/mdcb/docker-compose.yml
+++ b/deployments/mdcb/docker-compose.yml
@@ -25,7 +25,9 @@ services:
       - TYK_INSTRUMENTATION=${INSTRUMENTATION_ENABLED:-0}
       - TYK_GW_TRACER_ENABLED=${TRACING_ENABLED:-0}
       - TYK_GW_SLAVEOPTIONS_APIKEY=${MDCB_USER_API_CREDENTIALS:-placeholder}
-      - TYK_GW_SLAVEOPTIONS_GROUPID=${GATEWAY_WORKER_GROUPID:-default}
+      - TYK_GW_SLAVEOPTIONS_GROUPID=${GATEWAY_WORKER_GROUPID:-gw-internal}
+      - TYK_GW_DBAPPCONFOPTIONS_TAGS=${GATEWAY_WORKER_TAGS:-}
+      - TYK_GW_DBAPPCONFOPTIONS_NODEISSEGMENTED=${GATEWAY_WORKER_NODE_IS_SEGMENTED:-false}
       - TYK_GW_OPENTELEMETRY_ENABLED=${OPENTELEMETRY_ENABLED:-false}
       - TYK_GW_OPENTELEMETRY_ENDPOINT=${OPENTELEMETRY_ENDPOINT:-false}
       - TYK_DB_STREAMING_ENABLED=true
@@ -50,10 +52,13 @@ services:
       - TYK_INSTRUMENTATION=${INSTRUMENTATION_ENABLED:-0}
       - TYK_GW_TRACER_ENABLED=${TRACING_ENABLED:-0}
       - TYK_GW_SLAVEOPTIONS_APIKEY=${MDCB_USER_API_CREDENTIALS:-placeholder}
-      - TYK_GW_SLAVEOPTIONS_GROUPID=${GATEWAY_WORKER_GROUPID:-default}
+      - TYK_GW_SLAVEOPTIONS_GROUPID=${GATEWAY_WORKER_NGROK_GROUPID:-gw-external}
+      - TYK_GW_DBAPPCONFOPTIONS_TAGS=${GATEWAY_WORKER_NGROK_TAGS:-}
+      - TYK_GW_DBAPPCONFOPTIONS_NODEISSEGMENTED=${GATEWAY_WORKER_NGROK_NODE_IS_SEGMENTED:-false}
       - TYK_GW_OPENTELEMETRY_ENABLED=${OPENTELEMETRY_ENABLED:-false}
       - TYK_GW_OPENTELEMETRY_ENDPOINT=${OPENTELEMETRY_ENDPOINT:-false}
       - TYK_GW_SLAVEOPTIONS_CONNECTIONSTRING=${NGROK_MDCB_TUNNEL_URL:-placeholder}
+      - TYK_GW_STORAGE_HOST=tyk-worker-redis-ngrok
     volumes:
       - ./deployments/mdcb/volumes/tyk-worker-gateway/tyk.conf:/opt/tyk-gateway/tyk.conf
       - tyk-gateway-certs:/opt/tyk-gateway/certs
@@ -62,7 +67,7 @@ services:
     env_file:
       - .env
     depends_on:
-      - tyk-worker-redis
+      - tyk-worker-redis-ngrok
       - tyk-mdcb
       - tyk-dashboard
   tyk-worker-redis:
@@ -73,6 +78,15 @@ services:
       - "63791:6379"
     networks:
       - tyk
+  tyk-worker-redis-ngrok:
+    image: redis:7.2.0
+    volumes:
+      - tyk-worker-redis-ngrok-data:/data
+    ports:
+      - "63792:6379"
+    networks:
+      - tyk
 
 volumes:
   tyk-worker-redis-data:
+  tyk-worker-redis-ngrok-data:

--- a/deployments/opentelemetry-demo/scripts/continuous-traffic-gen.js
+++ b/deployments/opentelemetry-demo/scripts/continuous-traffic-gen.js
@@ -1,0 +1,551 @@
+/**
+ * Continuous Traffic Generator for Tyk Demo OTel Observability
+ *
+ * Replicates all four one-shot bash scripts in a single k6 script that runs
+ * continuously, producing sustained signal across all Grafana dashboards.
+ *
+ * Setup: creates (or recreates) all required Tyk APIs, policies, keys and
+ * OAuth clients once before traffic begins.
+ *
+ * Usage:
+ *   USER_API_KEY=$(grep "API Key:" logs/bootstrap.log | head -1 | awk '{print $NF}')
+ *   k6 run --env USER_API_KEY=$USER_API_KEY \
+ *           deployments/opentelemetry-demo/scripts/continuous-traffic-gen.js
+ *
+ * Options (via --env):
+ *   GATEWAY_URL   default: http://tyk-gateway.localhost:8080
+ *   DASHBOARD_URL default: http://tyk-dashboard.localhost:3000
+ *   GATEWAY_SECRET default: 28d220fd77974a4facfb07dc1e49c2aa
+ *   DURATION      default: 30m
+ *   CLEANUP       set to "true" to delete created resources on teardown
+ */
+
+import http from 'k6/http';
+import { check } from 'k6';
+import encoding from 'k6/encoding';
+
+// ─── Config ────────────────────────────────────────────────────────────────────
+
+const GATEWAY_URL = __ENV.GATEWAY_URL || 'http://tyk-gateway.localhost:8080';
+const DASHBOARD_URL = __ENV.DASHBOARD_URL || 'http://tyk-dashboard.localhost:3000';
+const GATEWAY_SECRET = __ENV.GATEWAY_SECRET || '28d220fd77974a4facfb07dc1e49c2aa';
+const USER_API_KEY = __ENV.USER_API_KEY || '';
+const DURATION = __ENV.DURATION || '30m';
+
+// ─── Scenarios ─────────────────────────────────────────────────────────────────
+
+export const options = {
+  scenarios: {
+    tenant_traffic: {
+      executor: 'constant-arrival-rate',
+      exec: 'tenantTraffic',
+      rate: 1,
+      timeUnit: '2s',
+      duration: DURATION,
+      preAllocatedVUs: 3,
+    },
+    version_traffic: {
+      executor: 'constant-arrival-rate',
+      exec: 'versionTraffic',
+      rate: 1,
+      timeUnit: '3s',
+      duration: DURATION,
+      preAllocatedVUs: 2,
+    },
+    oauth_traffic: {
+      executor: 'constant-arrival-rate',
+      exec: 'oauthTraffic',
+      rate: 1,
+      timeUnit: '4s',
+      duration: DURATION,
+      preAllocatedVUs: 2,
+    },
+    cache_traffic: {
+      executor: 'constant-arrival-rate',
+      exec: 'cacheTraffic',
+      rate: 1,
+      timeUnit: '2s',
+      duration: DURATION,
+      preAllocatedVUs: 2,
+    },
+    quota_traffic: {
+      executor: 'constant-arrival-rate',
+      exec: 'quotaTraffic',
+      rate: 1,
+      timeUnit: '3s',
+      duration: DURATION,
+      preAllocatedVUs: 2,
+    },
+    rate_limit_traffic: {
+      executor: 'constant-arrival-rate',
+      exec: 'rateLimitTraffic',
+      rate: 5,
+      timeUnit: '1s',
+      duration: DURATION,
+      preAllocatedVUs: 3,
+    },
+  },
+};
+
+// ─── Per-VU state ──────────────────────────────────────────────────────────────
+// k6 gives each VU its own JS context, so module-level variables are per-VU.
+
+const _counters = {};
+const _oauthTokens = {};
+
+function counter(name) {
+  _counters[name] = (_counters[name] || 0) + 1;
+  return _counters[name] - 1;
+}
+
+// ─── Setup helpers ─────────────────────────────────────────────────────────────
+
+function authHeaders() {
+  return { 'Authorization': USER_API_KEY, 'Content-Type': 'application/json' };
+}
+
+function reloadGateway() {
+  const resp = http.get(`${GATEWAY_URL}/tyk/reload/group?block=true`, {
+    headers: { 'x-tyk-authorization': GATEWAY_SECRET },
+  });
+  console.log(`Gateway reload: ${resp.json('status')}`);
+}
+
+function deleteApisByListenPaths(paths) {
+  const resp = http.get(`${DASHBOARD_URL}/api/apis?p=-1`, {
+    headers: { 'Authorization': USER_API_KEY },
+  });
+  const apis = (resp.json('apis') || []);
+  for (const api of apis) {
+    const lp = (api.api_definition && api.api_definition.proxy && api.api_definition.proxy.listen_path) || '';
+    if (paths.indexOf(lp) !== -1) {
+      const apiId = api.api_definition.api_id;
+      http.del(`${DASHBOARD_URL}/api/apis/${apiId}`, null, {
+        headers: { 'Authorization': USER_API_KEY },
+      });
+      console.log(`Deleted stale API: ${apiId} (${lp})`);
+    }
+  }
+}
+
+function deletePoliciesByNames(names) {
+  const resp = http.get(`${DASHBOARD_URL}/api/portal/policies?p=-1`, {
+    headers: { 'Authorization': USER_API_KEY },
+  });
+  const policies = (resp.json('Data') || []);
+  for (const policy of policies) {
+    if (names.indexOf(policy.name) !== -1) {
+      http.del(`${DASHBOARD_URL}/api/portal/policies/${policy._id}`, null, {
+        headers: { 'Authorization': USER_API_KEY },
+      });
+      console.log(`Deleted stale policy: ${policy._id} (${policy.name})`);
+    }
+  }
+}
+
+function createApi(def) {
+  const resp = http.post(`${DASHBOARD_URL}/api/apis`, JSON.stringify(def), {
+    headers: authHeaders(),
+  });
+  check(resp, { 'api created (200/201)': (r) => r.status === 200 || r.status === 201 });
+  const docId = resp.json('Meta');
+  const apiResp = http.get(`${DASHBOARD_URL}/api/apis/${docId}`, {
+    headers: { 'Authorization': USER_API_KEY },
+  });
+  const apiId = apiResp.json('api_definition.api_id');
+  console.log(`  Created API "${def.api_definition.name}": ${apiId}`);
+  return apiId;
+}
+
+function createPolicy(def) {
+  const resp = http.post(`${DASHBOARD_URL}/api/portal/policies`, JSON.stringify(def), {
+    headers: authHeaders(),
+  });
+  check(resp, { 'policy created': (r) => r.status === 200 || r.status === 201 });
+  // Dashboard API returns the policy ID in 'Message', not '_id'
+  const id = resp.json('_id') || resp.json('Message');
+  console.log(`  Created policy "${def.name}": ${id}`);
+  return id;
+}
+
+function createKey(orgId, policyId) {
+  const payload = {
+    apply_policy_id: policyId,
+    org_id: orgId,
+    allowance: 0,
+    rate: 0,
+    per: 0,
+    expires: -1,
+    quota_max: -1,
+    quota_renewal_rate: 3600,
+    quota_remaining: -1,
+    quota_renews: 0,
+    is_inactive: false,
+    access_rights: {},
+  };
+  const resp = http.post(`${DASHBOARD_URL}/api/keys`, JSON.stringify(payload), {
+    headers: authHeaders(),
+  });
+  check(resp, { 'key created': (r) => r.status === 200 || r.status === 201 });
+  const data = resp.json();
+  return data.key_id || data.key || data.key_hash;
+}
+
+function fetchOAuthToken(clientId, clientSecret) {
+  const basic = encoding.b64encode(`${clientId}:${clientSecret}`);
+  const resp = http.post(
+    `${GATEWAY_URL}/oauth-demo/oauth/token/`,
+    'grant_type=client_credentials',
+    {
+      headers: {
+        'Authorization': `Basic ${basic}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }
+  );
+  check(resp, { 'oauth token fetched': (r) => r.status === 200 });
+  return resp.json('access_token');
+}
+
+// ─── Setup ─────────────────────────────────────────────────────────────────────
+
+export function setup() {
+  if (!USER_API_KEY) {
+    throw new Error(
+      'USER_API_KEY is required.\n' +
+      "  Extract it with: grep \"API Key:\" logs/bootstrap.log | head -1 | awk '{print $NF}'\n" +
+      '  Then pass it: k6 run --env USER_API_KEY=<key> ...'
+    );
+  }
+
+  // 1. Get org_id
+  const usersResp = http.get(`${DASHBOARD_URL}/api/users`, {
+    headers: { 'Authorization': USER_API_KEY },
+  });
+  check(usersResp, { 'got org_id': (r) => r.status === 200 });
+  const users = usersResp.json('users');
+  const orgId = users[0].org_id;
+  console.log(`Org ID: ${orgId}`);
+
+  // 2. Clean up stale resources
+  console.log('Cleaning up stale APIs and policies...');
+  deleteApisByListenPaths(['/tenant-demo/', '/version-demo/', '/oauth-demo/', '/cache-demo/', '/quota-demo/']);
+  deletePoliciesByNames(['OAuth Demo Policy', 'Quota Low Policy', 'Quota Mid Policy', 'Quota High Policy', 'Rate Limit Burst Policy']);
+
+  // 3. Create APIs
+  console.log('Creating APIs...');
+
+  const tenantApiId = createApi({
+    api_definition: {
+      name: 'Tenant Demo API', slug: 'tenant-demo', api_id: '', org_id: orgId,
+      use_keyless: true, use_oauth2: false, active: true,
+      proxy: { listen_path: '/tenant-demo/', target_url: 'http://httpbin/', strip_listen_path: true },
+      version_data: {
+        not_versioned: true, default_version: 'Default',
+        versions: { Default: { name: 'Default', use_extended_paths: true, extended_paths: {} } },
+      },
+    },
+    hook_references: [], is_site: false, sort_by: 0, user_group_owners: [], user_owners: [],
+  });
+
+  const _versionApiId = createApi({
+    api_definition: {
+      name: 'Version Demo API #otel-demo', slug: 'version-demo', api_id: '', org_id: orgId,
+      use_keyless: true, use_oauth2: false, active: true, enable_detailed_recording: true,
+      proxy: { listen_path: '/version-demo/', target_url: 'http://httpbin/', strip_listen_path: true },
+      version_data: {
+        not_versioned: true, default_version: 'Default',
+        versions: { Default: { name: 'Default', use_extended_paths: true, extended_paths: {} } },
+      },
+    },
+    hook_references: [], is_site: false, sort_by: 0, user_group_owners: [], user_owners: [],
+  });
+
+  const oauthApiId = createApi({
+    api_definition: {
+      name: 'OAuth Demo API', slug: 'oauth-demo', api_id: '', org_id: orgId,
+      use_keyless: false, use_oauth2: true, active: true,
+      oauth_meta: { allowed_access_types: ['client_credentials'], allowed_authorize_types: [], auth_login_redirect: '' },
+      auth: { auth_header_name: 'Authorization' },
+      notifications: { shared_secret: '', oauth_on_keychange_url: '' },
+      proxy: { listen_path: '/oauth-demo/', target_url: 'http://httpbin/', strip_listen_path: true },
+      version_data: {
+        not_versioned: true, default_version: 'Default',
+        versions: { Default: { name: 'Default', use_extended_paths: true, extended_paths: {} } },
+      },
+    },
+    hook_references: [], is_site: false, sort_by: 0, user_group_owners: [], user_owners: [],
+  });
+
+  const _cacheApiId = createApi({
+    api_definition: {
+      name: 'Cache Demo API', slug: 'cache-demo', api_id: '', org_id: orgId,
+      use_keyless: true, active: true,
+      proxy: { listen_path: '/cache-demo/', target_url: 'http://httpbin/', strip_listen_path: true },
+      cache_options: { cache_timeout: 60, enable_cache: true, cache_all_safe_requests: true, cache_response_codes: [200] },
+      version_data: {
+        not_versioned: true, default_version: 'Default',
+        versions: { Default: { name: 'Default', use_extended_paths: true, extended_paths: {} } },
+      },
+    },
+    hook_references: [], is_site: false, sort_by: 0, user_group_owners: [], user_owners: [],
+  });
+
+  const quotaApiId = createApi({
+    api_definition: {
+      name: 'Quota Demo API', slug: 'quota-demo', api_id: '', org_id: orgId,
+      use_keyless: false, use_oauth2: false, active: true,
+      auth: { auth_header_name: 'x-api-key' },
+      proxy: { listen_path: '/quota-demo/', target_url: 'http://httpbin/', strip_listen_path: true },
+      version_data: {
+        not_versioned: true, default_version: 'Default',
+        versions: { Default: { name: 'Default', use_extended_paths: true, extended_paths: {} } },
+      },
+    },
+    hook_references: [], is_site: false, sort_by: 0, user_group_owners: [], user_owners: [],
+  });
+
+  // 4. Reload gateway so APIs are registered
+  console.log('Reloading gateway after API creation...');
+  reloadGateway();
+
+  // 5. Create OAuth access policy
+  console.log('Creating policies...');
+  const oauthPolicyId = createPolicy({
+    name: 'OAuth Demo Policy', rate: 1000, per: 60, quota_max: -1, quota_renewal_rate: -1,
+    org_id: orgId, active: true, tags: [], is_inactive: false,
+    access_rights: {
+      [oauthApiId]: { api_id: oauthApiId, api_name: 'OAuth Demo API', versions: ['Default'] },
+    },
+  });
+
+  // 6. Create quota policies (low=30/day@2rps, mid=100/day@10rps, high=500/day@50rps)
+  const polLowId = createPolicy({
+    name: 'Quota Low Policy', rate: 2, per: 1, quota_max: 30, quota_renewal_rate: 3600,
+    org_id: orgId, active: true, tags: [], is_inactive: false,
+    access_rights: {
+      [quotaApiId]: { api_id: quotaApiId, api_name: 'Quota Demo API', versions: ['Default'] },
+    },
+  });
+  const polMidId = createPolicy({
+    name: 'Quota Mid Policy', rate: 10, per: 1, quota_max: 100, quota_renewal_rate: 3600,
+    org_id: orgId, active: true, tags: [], is_inactive: false,
+    access_rights: {
+      [quotaApiId]: { api_id: quotaApiId, api_name: 'Quota Demo API', versions: ['Default'] },
+    },
+  });
+  const polHighId = createPolicy({
+    name: 'Quota High Policy', rate: 50, per: 1, quota_max: 500, quota_renewal_rate: 3600,
+    org_id: orgId, active: true, tags: [], is_inactive: false,
+    access_rights: {
+      [quotaApiId]: { api_id: quotaApiId, api_name: 'Quota Demo API', versions: ['Default'] },
+    },
+  });
+  // Rate-limit burst policy: low rate (2 req/s) but unlimited quota so rejections are
+  // always 429 (rate limited) rather than 403 (quota exhausted)
+  const polBurstId = createPolicy({
+    name: 'Rate Limit Burst Policy', rate: 2, per: 1, quota_max: -1, quota_renewal_rate: -1,
+    org_id: orgId, active: true, tags: [], is_inactive: false,
+    access_rights: {
+      [quotaApiId]: { api_id: quotaApiId, api_name: 'Quota Demo API', versions: ['Default'] },
+    },
+  });
+
+  // 7. Reload gateway to sync new policies
+  console.log('Reloading gateway to sync policies...');
+  reloadGateway();
+
+  // 8. Create quota API keys
+  console.log('Creating keys...');
+  const keyLow = createKey(orgId, polLowId);
+  const keyMid = createKey(orgId, polMidId);
+  const keyHigh = createKey(orgId, polHighId);
+  const keyBurst = createKey(orgId, polBurstId);
+  console.log(`  key-low: ${keyLow}  key-mid: ${keyMid}  key-high: ${keyHigh}  key-burst: ${keyBurst}`);
+
+  // 9. Create OAuth clients
+  console.log('Creating OAuth clients...');
+  const oauthClients = [
+    { id: 'client-alpha', secret: 'secret-client-alpha' },
+    { id: 'client-beta',  secret: 'secret-client-beta'  },
+    { id: 'client-gamma', secret: 'secret-client-gamma' },
+  ];
+  for (const client of oauthClients) {
+    const resp = http.post(
+      `${DASHBOARD_URL}/api/apis/oauth/${oauthApiId}`,
+      JSON.stringify({
+        api_id: oauthApiId,
+        client_id: client.id,
+        secret: client.secret,
+        redirect_uri: 'http://localhost',
+        policy_id: oauthPolicyId,
+      }),
+      { headers: authHeaders() }
+    );
+    console.log(`  OAuth client: ${resp.json('client_id')}`);
+  }
+
+  // 10. Get initial access tokens for each OAuth client
+  console.log('Fetching OAuth access tokens...');
+  const tokens = {};
+  for (const client of oauthClients) {
+    tokens[client.id] = fetchOAuthToken(client.id, client.secret);
+    console.log(`  ${client.id}: ${String(tokens[client.id]).substring(0, 24)}...`);
+  }
+
+  console.log('\nSetup complete — traffic scenarios starting.\n');
+
+  return {
+    orgId,
+    oauthClients,
+    tokens,
+    quotaKeys: { low: keyLow, mid: keyMid, high: keyHigh, burst: keyBurst },
+  };
+}
+
+// ─── Scenario: Tenant Traffic ──────────────────────────────────────────────────
+// Replicates tenant-traffic-gen.sh
+// Metrics: tyk_requests_by_tenant_total, tyk_latency_by_tenant_seconds,
+//          tyk_requests_by_customer_total (panels 131–134)
+
+const TENANTS   = ['tenant-alpha', 'tenant-beta', 'tenant-gamma'];
+const CUSTOMERS = ['cust-001', 'cust-002', 'cust-003'];
+
+export function tenantTraffic(_data) {
+  const n = counter('tenant');
+  const tenant   = TENANTS[n % TENANTS.length];
+  const customer = CUSTOMERS[n % CUSTOMERS.length];
+  // Every 5th request generates a 500 to populate error-rate panels
+  const isError = (n % 5 === 4);
+  const url = isError
+    ? `${GATEWAY_URL}/tenant-demo/status/500`
+    : `${GATEWAY_URL}/tenant-demo/get`;
+
+  const resp = http.get(url, {
+    headers: { 'X-Tenant-ID': tenant, 'X-Customer-ID': customer },
+  });
+  check(resp, {
+    'tenant traffic: expected status': (r) => isError ? r.status === 500 : r.status === 200,
+  });
+}
+
+// ─── Scenario: Version Traffic ─────────────────────────────────────────────────
+// Replicates version-traffic-gen.sh
+// Metrics: tyk_requests_by_backend_version_total, tyk_requests_by_content_type_total
+//          (panels 144–145)
+
+// 9 slots to achieve v1:v2:v3 = 4:3:2 ratio
+const VERSION_PATHS = [
+  'response-headers?X-Backend-Version=v1&Content-Type=application/json',
+  'response-headers?X-Backend-Version=v1&Content-Type=application/json',
+  'response-headers?X-Backend-Version=v1&Content-Type=application/json',
+  'response-headers?X-Backend-Version=v1&Content-Type=application/json',
+  'response-headers?X-Backend-Version=v2&Content-Type=text/html',
+  'response-headers?X-Backend-Version=v2&Content-Type=text/html',
+  'response-headers?X-Backend-Version=v2&Content-Type=text/html',
+  'response-headers?X-Backend-Version=v3&Content-Type=application/gzip',
+  'response-headers?X-Backend-Version=v3&Content-Type=application/gzip',
+];
+
+export function versionTraffic(_data) {
+  const n = counter('version');
+  const path = VERSION_PATHS[n % VERSION_PATHS.length];
+  const resp = http.get(`${GATEWAY_URL}/version-demo/${path}`);
+  check(resp, { 'version traffic: status 200': (r) => r.status === 200 });
+}
+
+// ─── Scenario: OAuth Traffic ───────────────────────────────────────────────────
+// Replicates oauth-traffic-gen.sh
+// Metrics: tyk_requests_by_oauth_total (panels 123–124)
+
+export function oauthTraffic(data) {
+  const n = counter('oauth');
+  const client = data.oauthClients[n % data.oauthClients.length];
+
+  // Use per-VU token cache; fall back to initial tokens from setup
+  let token = _oauthTokens[client.id] || data.tokens[client.id];
+
+  // Every 5th request generates a 500 to populate error-rate panels
+  const isError = (n % 5 === 4);
+  const url = isError
+    ? `${GATEWAY_URL}/oauth-demo/status/500`
+    : `${GATEWAY_URL}/oauth-demo/get`;
+
+  let resp = http.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
+
+  // Refresh token on 401 (expired) and retry once
+  if (resp.status === 401) {
+    token = fetchOAuthToken(client.id, client.secret);
+    _oauthTokens[client.id] = token;
+    resp = http.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
+  }
+
+  check(resp, {
+    'oauth traffic: expected status': (r) => r.status === 200 || r.status === 500,
+  });
+}
+
+// ─── Scenario: Cache Traffic ───────────────────────────────────────────────────
+// Replicates the cache portion of traffic-control-demo.sh
+// Metrics: tyk_requests_with_cache_total (panels 141–143)
+
+export function cacheTraffic(_data) {
+  const n = counter('cache');
+  // 10% of requests hit a unique path (cache miss); 90% reuse the same path (cache hit)
+  const isMiss = (n % 10 === 0);
+  const url = isMiss
+    ? `${GATEWAY_URL}/cache-demo/anything/miss-${n}` // unique → miss
+    : `${GATEWAY_URL}/cache-demo/get`;               // fixed  → hit after first request
+
+  const resp = http.get(url, { headers: { 'x-request-id': 'cache-test' } });
+  check(resp, { 'cache traffic: status 200': (r) => r.status === 200 });
+}
+
+// ─── Scenario: Quota Traffic ───────────────────────────────────────────────────
+// Replicates the quota portion of traffic-control-demo.sh
+// Metrics: tyk_requests_by_quota_limit_total, tyk_api_requests_total{429}
+//          (panels 171–174)
+
+export function quotaTraffic(data) {
+  const n = counter('quota');
+  const { low, mid, high } = data.quotaKeys;
+  // 10-slot distribution: low≈30%, mid≈40%, high≈30%
+  const slots = [low, low, low, mid, mid, mid, mid, high, high, high];
+  const key = slots[n % slots.length];
+
+  const resp = http.get(`${GATEWAY_URL}/quota-demo/get`, {
+    headers: { 'x-api-key': key },
+  });
+  // 429 (rate limit) and 403 (quota exhausted) are expected and populate rejection panels
+  check(resp, {
+    'quota traffic: ok or rejected': (r) => r.status === 200 || r.status === 429 || r.status === 403,
+  });
+}
+
+// ─── Scenario: Rate Limit Traffic ─────────────────────────────────────────────
+// Deliberately fires at 5 req/s against a key limited to 2 req/s, producing a
+// steady stream of 429 (rate limited) responses. The policy has quota_max=-1 so
+// rejections are always 429, never 403 (quota exhausted).
+
+export function rateLimitTraffic(data) {
+  const resp = http.get(`${GATEWAY_URL}/quota-demo/get`, {
+    headers: { 'x-api-key': data.quotaKeys.burst },
+  });
+  // ~60% of requests will be 429 (rate limited) at 5 req/s vs 2 req/s limit
+  check(resp, {
+    'rate limit traffic: ok or rate limited': (r) => r.status === 200 || r.status === 429,
+  });
+}
+
+// ─── Teardown ──────────────────────────────────────────────────────────────────
+
+export function teardown(_data) {
+  if (__ENV.CLEANUP !== 'true') {
+    console.log('Teardown: skipping cleanup (pass --env CLEANUP=true to remove resources)');
+    return;
+  }
+  console.log('Teardown: removing created APIs and policies...');
+  deleteApisByListenPaths(['/tenant-demo/', '/version-demo/', '/oauth-demo/', '/cache-demo/', '/quota-demo/']);
+  deletePoliciesByNames(['OAuth Demo Policy', 'Quota Low Policy', 'Quota Mid Policy', 'Quota High Policy', 'Rate Limit Burst Policy']);
+  console.log('Teardown complete.');
+}

--- a/deployments/opentelemetry-demo/scripts/version-traffic-gen.sh
+++ b/deployments/opentelemetry-demo/scripts/version-traffic-gen.sh
@@ -60,7 +60,7 @@ API_DEF=$(cat <<EOF
     "use_oauth2": false,
     "proxy": {
       "listen_path": "$LISTEN_PATH/",
-      "target_url": "http://httpbin.org/",
+      "target_url": "http://httpbin/",
       "strip_listen_path": true
     },
     "active": true,

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo-backup/tyk-gateway-otlp-metrics.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo-backup/tyk-gateway-otlp-metrics.json
@@ -3245,47 +3245,6 @@
       ]
     },
     {
-      "id": 174,
-      "type": "timeseries",
-      "title": "Traffic by Quota Tier",
-      "description": "Requests grouped by the X-RateLimit-Limit quota ceiling per key/policy. Shows which quota tiers are active. quota_limit='0' (keyless/no quota) filtered out. Requires tyk.requests.by.quota_limit counter with response_header X-RateLimit-Limit dimension.",
-      "gridPos": {
-        "x": 0,
-        "y": 173,
-        "w": 24,
-        "h": 8
-      },
-      "datasource": "${datasource_prometheus}",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
-          },
-          "noValue": "Configure tyk.requests.by.quota_limit metric"
-        }
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "${datasource_prometheus}",
-          "expr": "sum by(quota_limit)(rate(tyk_requests_by_quota_limit_total{service_name=~\"$service_name\", quota_limit!=\"0\", api_id=~\"$api_id\"}[$__rate_interval]))",
-          "legendFormat": "Quota: {{quota_limit}} req/period",
-          "refId": "A"
-        }
-      ]
-    },
-    {
       "id": 150,
       "type": "row",
       "title": "Context Variable Dimensions \u2014 Business Logic Segmentation (Tier, Plan, Region)",

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
@@ -32,10 +32,37 @@
         "hide": 0
       },
       {
+        "name": "tyk_gw_group_id",
+        "type": "query",
+        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "query": "label_values(tyk_gateway_apis_loaded, tyk_gw_group_id)",
+        "label": "Group / Cluster",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {},
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "tyk_gw_id",
+        "type": "query",
+        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "query": "label_values(tyk_gateway_apis_loaded{tyk_gw_group_id=~\"$tyk_gw_group_id\"}, tyk_gw_id)",
+        "label": "Gateway Node",
+        "multi": true,
+        "includeAll": true,
+        "current": {},
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0
+      },
+      {
         "name": "api_id",
         "type": "query",
         "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-        "query": "label_values(tyk_api_requests_total{service_name=~\"$service_name\"}, tyk_api_id)",
+        "query": "label_values(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, tyk_api_id)",
         "label": "API",
         "multi": true,
         "includeAll": true,
@@ -49,7 +76,7 @@
         "name": "method",
         "type": "query",
         "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-        "query": "label_values(tyk_api_requests_total{service_name=~\"$service_name\"}, http_request_method)",
+        "query": "label_values(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, http_request_method)",
         "label": "Method",
         "multi": true,
         "includeAll": true,
@@ -63,7 +90,7 @@
         "name": "org_id",
         "type": "query",
         "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-        "query": "label_values(tyk_requests_by_org_total{service_name=~\"$service_name\"}, org_id)",
+        "query": "label_values(tyk_requests_by_org_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, org_id)",
         "label": "Org",
         "multi": true,
         "includeAll": true,
@@ -77,7 +104,7 @@
         "name": "tenant_id",
         "type": "query",
         "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-        "query": "label_values(tyk_requests_by_tenant_total{service_name=~\"$service_name\"}, tenant_id)",
+        "query": "label_values(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, tenant_id)",
         "label": "Tenant",
         "multi": true,
         "includeAll": true,
@@ -137,7 +164,7 @@
       "title": "Request Rate",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } }
     },
@@ -148,7 +175,7 @@
       "description": "Server errors as % of total. Green <1%, Amber 1-5%, Red >5%.",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 4, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] } } }
     },
@@ -159,7 +186,7 @@
       "description": "Client errors as % of total. Green <5%, Amber 5-15%, Red >15%.",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 7, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 5 }, { "color": "red", "value": 15 }] } } }
     },
@@ -170,7 +197,7 @@
       "description": "End-to-end P95 latency seen by clients. Green <500ms, Amber 500-1000ms, Red >1s.",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 10, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 1000 }] } } }
     },
@@ -181,7 +208,7 @@
       "description": "Tyk's own processing overhead at P95. High value indicates policy execution or plugin issues.",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 14, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 300 }] } } }
     },
@@ -192,7 +219,7 @@
       "description": "Backend service P95 latency. High value = backend is slow, not Tyk.",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 17, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 1000 }] } } }
     },
@@ -202,7 +229,7 @@
       "title": "Active APIs",
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "count(count by(tyk_api_id)(tyk_api_requests_total{service_name=~\"$service_name\"}))", "instant": true }],
+      "targets": [{ "refId": "A", "expr": "count(count by(tyk_api_id)(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}))", "instant": true }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } }
     },
@@ -221,10 +248,10 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 6, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"2..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "2xx" },
-        { "refId": "B", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"3..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "3xx" },
-        { "refId": "C", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "4xx" },
-        { "refId": "D", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "5xx" }
+        { "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"2..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "2xx" },
+        { "refId": "B", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"3..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "3xx" },
+        { "refId": "C", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "4xx" },
+        { "refId": "D", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "5xx" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -236,7 +263,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 8, "y": 6, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}" }
+        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -249,9 +276,9 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 16, "y": 6, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Total P95" },
-        { "refId": "B", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Gateway P95" },
-        { "refId": "C", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Upstream P95" }
+        { "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Total P95" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Gateway P95" },
+        { "refId": "C", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Upstream P95" }
       ],
       "fieldConfig": { "defaults": { "unit": "ms", "custom": { "lineWidth": 2, "fillOpacity": 8 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -271,7 +298,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 15, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100", "legendFormat": "{{tyk_api_id}}" }
+        { "refId": "A", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100", "legendFormat": "{{tyk_api_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -283,7 +310,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 8, "y": 15, "w": 6, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100)", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100)", "legendFormat": "{{tyk_api_id}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "color": { "mode": "continuous-RdYlGr" } } }
@@ -296,7 +323,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 14, "y": 15, "w": 5, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sum by(tyk_response_flag)(increase(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range]))", "legendFormat": "{{tyk_response_flag}}" }
+        { "refId": "A", "expr": "sum by(tyk_response_flag)(increase(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range]))", "legendFormat": "{{tyk_response_flag}}" }
       ],
       "options": { "pieType": "donut", "displayLabels": ["percent", "name"], "legend": { "displayMode": "list", "placement": "bottom" } },
       "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
@@ -308,7 +335,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 19, "y": 15, "w": 5, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sort_desc(sum by(http_response_status_code)(increase(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range])))", "legendFormat": "{{http_response_status_code}}", "instant": true, "format": "table" }
+        { "refId": "A", "expr": "sort_desc(sum by(http_response_status_code)(increase(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range])))", "legendFormat": "{{http_response_status_code}}", "instant": true, "format": "table" }
       ],
       "options": { "xField": "http_response_status_code", "orientation": "vertical" },
       "fieldConfig": { "defaults": { "unit": "short", "displayName": "Requests", "color": { "mode": "palette-classic" } } }
@@ -321,7 +348,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 23, "w": 12, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{tyk_api_id}}" }
+        { "refId": "A", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{tyk_api_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -333,7 +360,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 12, "y": 23, "w": 12, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } } }
@@ -353,7 +380,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 31, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "continuous-BlYlRd" } } }
@@ -365,7 +392,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 8, "y": 31, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000)", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000)", "legendFormat": "{{tyk_api_id}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "continuous-GrYlRd" } } }
@@ -377,7 +404,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 16, "y": 31, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100)", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100)", "legendFormat": "{{tyk_api_id}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "color": { "mode": "continuous-RdYlGr" } } }
@@ -390,12 +417,12 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 39, "w": 24, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.50, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "B", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "C", "expr": "histogram_quantile(0.99, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "D", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "E", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "F", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" }
+        { "refId": "A", "expr": "histogram_quantile(0.50, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
+        { "refId": "C", "expr": "histogram_quantile(0.99, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
+        { "refId": "D", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
+        { "refId": "E", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
+        { "refId": "F", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" }
       ],
       "options": { "sortBy": [{ "displayName": "Total P95 (ms)", "desc": true }] },
       "transformations": [
@@ -419,7 +446,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 48, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(org_id)(rate(tyk_requests_by_org_total{service_name=~\"$service_name\", org_id=~\"$org_id\", method=~\"$method\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{org_id}}" }
+        { "refId": "A", "expr": "sum by(org_id)(rate(tyk_requests_by_org_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", org_id=~\"$org_id\", method=~\"$method\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{org_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -431,7 +458,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 8, "y": 48, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{tenant_id}}" }
+        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{tenant_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -443,7 +470,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 16, "y": 48, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", response_code=~\"5..\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100", "legendFormat": "{{tenant_id}}" }
+        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", response_code=~\"5..\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100", "legendFormat": "{{tenant_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -456,10 +483,10 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 55, "w": 16, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
-        { "refId": "B", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", response_code=~\"5..\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval])) * 100", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
-        { "refId": "C", "expr": "histogram_quantile(0.50, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))) * 1000", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
-        { "refId": "D", "expr": "histogram_quantile(0.95, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))) * 1000", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" }
+        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
+        { "refId": "B", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", response_code=~\"5..\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval])) * 100", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
+        { "refId": "C", "expr": "histogram_quantile(0.50, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))) * 1000", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
+        { "refId": "D", "expr": "histogram_quantile(0.95, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))) * 1000", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" }
       ],
       "transformations": [
         { "id": "merge", "options": {} },
@@ -474,7 +501,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 16, "y": 55, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "{{tenant_id}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "{{tenant_id}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } } }
@@ -494,7 +521,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 64, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "...{{api_key_suffix}}" }
+        { "refId": "A", "expr": "sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "...{{api_key_suffix}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -506,7 +533,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 8, "y": 64, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "...{{api_key_suffix}}", "instant": true }
+        { "refId": "A", "expr": "topk(10, sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "...{{api_key_suffix}}", "instant": true }
       ],
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } } }
@@ -518,7 +545,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 16, "y": 64, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(oauth_client_id)(rate(tyk_requests_by_oauth_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{oauth_client_id}}" }
+        { "refId": "A", "expr": "sum by(oauth_client_id)(rate(tyk_requests_by_oauth_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{oauth_client_id}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -530,7 +557,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 71, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(portal_app)(increase(tyk_requests_by_portal_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__range]))", "legendFormat": "{{portal_app}}" }
+        { "refId": "A", "expr": "sum by(portal_app)(increase(tyk_requests_by_portal_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__range]))", "legendFormat": "{{portal_app}}" }
       ],
       "options": { "pieType": "pie", "displayLabels": ["percent", "name"], "legend": { "displayMode": "list", "placement": "right" } },
       "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
@@ -543,7 +570,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 8, "y": 71, "w": 16, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(subscription_tier)(rate(tyk_requests_by_tier_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{subscription_tier}}" }
+        { "refId": "A", "expr": "sum by(subscription_tier)(rate(tyk_requests_by_tier_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{subscription_tier}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -564,7 +591,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 79, "w": 6, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "(1 - sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))) * 100 or vector(100)", "instant": true }
+        { "refId": "A", "expr": "(1 - sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))) * 100 or vector(100)", "instant": true }
       ],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "showThresholdLabels": true, "showThresholdMarkers": true },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 95, "max": 100, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 99 }, { "color": "green", "value": 99.9 }] } } }
@@ -577,7 +604,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 6, "y": 79, "w": 6, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", le=\"1\"}[$__rate_interval])) / sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(100)", "instant": true }
+        { "refId": "A", "expr": "sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", le=\"1\"}[$__rate_interval])) / sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(100)", "instant": true }
       ],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "showThresholdLabels": true, "showThresholdMarkers": true },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 80, "max": 100, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 90 }, { "color": "green", "value": 99 }] } } }
@@ -590,7 +617,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 12, "y": 79, "w": 4, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "(1 - (sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[30d])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\"}[30d]))) / (1 - $slo_availability_target/100)) * 100 or vector(100)", "instant": true }
+        { "refId": "A", "expr": "(1 - (sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[30d])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[30d]))) / (1 - $slo_availability_target/100)) * 100 or vector(100)", "instant": true }
       ],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 25 }, { "color": "green", "value": 50 }] } } }
@@ -603,8 +630,8 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 16, "y": 79, "w": 8, "h": 8 },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[1h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\"}[1h])) / (1 - $slo_availability_target/100) or vector(0)", "legendFormat": "1h burn rate" },
-        { "refId": "B", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[6h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\"}[6h])) / (1 - $slo_availability_target/100) or vector(0)", "legendFormat": "6h burn rate" }
+        { "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[1h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[1h])) / (1 - $slo_availability_target/100) or vector(0)", "legendFormat": "1h burn rate" },
+        { "refId": "B", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[6h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[6h])) / (1 - $slo_availability_target/100) or vector(0)", "legendFormat": "6h burn rate" }
       ],
       "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 14.4 }] } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -616,7 +643,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 87, "w": 24, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "P95 Total Latency" },
+        { "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "P95 Total Latency" },
         { "refId": "B", "expr": "$slo_latency_ms + 0", "legendFormat": "SLO Threshold (${slo_latency_ms}ms)" }
       ],
       "fieldConfig": { "defaults": { "unit": "ms", "custom": { "lineWidth": 2, "fillOpacity": 8 } }, "overrides": [{ "matcher": { "id": "byName", "options": "SLO Threshold (${slo_latency_ms}ms)" }, "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }, { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }] },
@@ -637,7 +664,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 0, "y": 95, "w": 4, "h": 4 },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", cache_status=\"1\", api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }
+        { "refId": "A", "expr": "sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", cache_status=\"1\", api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }
       ],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "auto" },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 40 }, { "color": "green", "value": 70 }] } } }
@@ -650,7 +677,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 4, "y": 95, "w": 8, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(cache_status)(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "cache={{cache_status}}" }
+        { "refId": "A", "expr": "sum by(cache_status)(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "cache={{cache_status}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
@@ -662,7 +689,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 12, "y": 95, "w": 6, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "sum by(cache_status)(increase(tyk_requests_with_cache_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__range]))", "legendFormat": "cache={{cache_status}}" }
+        { "refId": "A", "expr": "sum by(cache_status)(increase(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__range]))", "legendFormat": "cache={{cache_status}}" }
       ],
       "options": { "pieType": "donut", "displayLabels": ["percent", "name"], "legend": { "displayMode": "list", "placement": "right" } },
       "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
@@ -675,7 +702,7 @@
       "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
       "gridPos": { "x": 18, "y": 95, "w": 6, "h": 7 },
       "targets": [
-        { "refId": "A", "expr": "label_replace(sum by(backend_version)(rate(tyk_requests_by_backend_version_total{service_name=~\"$service_name\", api_id=~\"$api_id\"}[$__rate_interval])), \"backend_version\", \"No version\", \"backend_version\", \"^$\")", "legendFormat": "{{backend_version}}" }
+        { "refId": "A", "expr": "label_replace(sum by(backend_version)(rate(tyk_requests_by_backend_version_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])), \"backend_version\", \"No version\", \"backend_version\", \"^$\")", "legendFormat": "{{backend_version}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
@@ -19,6 +19,14 @@
         "current": {}
       },
       {
+        "name": "datasource_loki",
+        "type": "datasource",
+        "query": "loki",
+        "label": "Loki",
+        "hide": 0,
+        "current": {}
+      },
+      {
         "name": "tyk_gw_id",
         "type": "query",
         "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
@@ -44,14 +52,6 @@
         "refresh": 2,
         "sort": 1,
         "hide": 0
-      },
-      {
-        "name": "datasource_loki",
-        "type": "datasource",
-        "query": "loki",
-        "label": "Loki",
-        "hide": 0,
-        "current": {}
       }
     ]
   },


### PR DESCRIPTION
Adds `tyk_gw_group_id` and `tyk_gw_id` filter variables to the API Portfolio and Fleet Health dashboards so operators can drill down by gateway cluster or individual node.

Auto-detects gateway tag configuration in the MDCB bootstrap script to set `NODE_IS_SEGMENTED` flags automatically, and updates the worker group ID default to `gw-internal`.

Fixes the httpbin target URL in the traffic generator to use the local container, and adds a new `continuous-traffic-gen.js` k6 script for sustained demo observability signal.