### PR TITLE
Improve Tyk OTLP dashboard suite: API names, path labels, fleet health, docs

### DIFF
--- a/.claude/skills/tyk-grafana-dashboard/SKILL.md
+++ b/.claude/skills/tyk-grafana-dashboard/SKILL.md
@@ -1,21 +1,32 @@
 ---
 name: tyk-grafana-dashboard
-description: Expert assistant for designing and debugging the Tyk Gateway Native OTLP Metrics Grafana dashboard. Knows all panel IDs, PromQL patterns, metric names, dimension sources, and MCP tools for live Prometheus/Grafana queries.
+description: Expert assistant for designing and debugging the Tyk Gateway OTLP Grafana dashboard suite (Fleet Health, API Portfolio, API Troubleshooting, Native OTLP Metrics). Knows panel IDs, PromQL/LogQL/TraceQL patterns, metric names, dimension sources, and MCP tools for live Prometheus/Loki/Tempo/Grafana queries.
 ---
 
-You are an expert on the **Tyk Gateway — Native OTLP Metrics** Grafana dashboard. You know every panel, every metric, every PromQL pattern, and all MCP tools needed to inspect, modify, and debug this dashboard.
+You are an expert on the **Tyk Gateway OTLP Grafana dashboard suite** — 4 interconnected dashboards covering fleet operations, API portfolio visibility, per-API troubleshooting, and custom OTLP metric exploration. You know every panel, every metric, every query pattern, and all MCP tools needed to inspect, modify, and debug any dashboard in this suite.
 
 ---
 
 ## 1. Dashboard Inventory
 
+### Overview
+
+All files are under `deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/`. Grafana base URL: `http://localhost:8085/grafana`. Dashboards 2–4 cross-link to each other via the dashboard-level `links` array (see Section 14).
+
+| # | UID | Title | File | Datasources | Audience |
+|---|-----|-------|------|-------------|----------|
+| 1 | `tyk-gateway-otlp-metrics` | Tyk Gateway — Native OTLP Metrics | `tyk-demo-backup/tyk-gateway-otlp-metrics.json` | Prometheus | Engineers exploring custom metrics |
+| 2 | `tyk-gateway-fleet-health` | Tyk Gateway — Fleet Health | `tyk-demo/tyk-gateway-fleet-health.json` | Prometheus + Loki | Platform / DevOps |
+| 3 | `tyk-api-portfolio` | Tyk Gateway — API Portfolio Overview | `tyk-demo/tyk-api-portfolio.json` | Prometheus | API platform leads, SRE on-call |
+| 4 | `tyk-api-troubleshooting` | Tyk Gateway — API Troubleshooting | `tyk-demo/tyk-api-troubleshooting.json` | Prometheus + Tempo + Loki | Backend engineers, SRE on-call |
+
+### tyk-gateway-otlp-metrics
+
 - **UID**: `tyk-gateway-otlp-metrics`
-- **Title**: "Tyk Gateway - Native OTLP Metrics"
-- **Grafana URL**: `http://localhost:8085/grafana`
-- **File**: `deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-otlp-metrics.json`
+- **File**: `tyk-demo-backup/tyk-gateway-otlp-metrics.json`
 - **Refresh**: 30s | **Default range**: now-1h
 
-### Panel Index (56 data panels)
+#### Panel Index (56 data panels)
 
 | ID | Type | Title | Row |
 |----|------|-------|-----|
@@ -76,6 +87,55 @@ You are an expert on the **Tyk Gateway — Native OTLP Metrics** Grafana dashboa
 
 Row 8 is a text/markdown explanation panel (no data panels). There is no standalone Quota Monitoring row — quota panels (171–174) live under Row 12 (Response Header Dims).
 
+### tyk-gateway-fleet-health
+
+- **UID**: `tyk-gateway-fleet-health`
+- **File**: `tyk-demo/tyk-gateway-fleet-health.json`
+- **Variables**: `tyk_gw_id` (multi, regex `.*`), `tyk_gw_group_id` (multi, regex `.*`)
+
+| Row | Key Panels |
+|-----|------------|
+| Fleet KPIs | Gateway count (stat), Total APIs loaded (stat), Total policies loaded (stat), Fleet request rate (stat) |
+| Deployment & Config State | APIs loaded per gateway (timeseries), Config drift gauge (`max - min` of `tyk_gateway_apis_loaded`), Config reloads over time |
+| Go Runtime Health | Heap pressure gauge (`go_memory_used_bytes / go_memory_limit_bytes`), Heap in use vs GC goal vs limit, Goroutine fleet snapshot |
+| Gateway Traffic & Load Distribution | Request rate per gateway (timeseries), Traffic distribution by gateway |
+| Edge & Multi-Region | (collapsed by default) |
+| Gateway Health Events | Log volume histogram by level — error/warn/info stacked bars (timeseries panel 61, w:8), Recent Gateway Errors log stream (panel 63, w:16), Upstream Failures by API table (panel 62, full width below) |
+
+### tyk-api-portfolio
+
+- **UID**: `tyk-api-portfolio`
+- **File**: `tyk-demo/tyk-api-portfolio.json`
+- **Variables**: `service_name`, `tyk_gw_group_id`, `tyk_gw_id`, `api_id` (multi, all), `method` (multi, all), `org_id` (multi, all), `slo_availability_target` (custom: 99/99.5/99.9/99.95/99.99, default 99.9), `slo_latency_ms` (custom: 200/500/1000/2000, default 500)
+
+| Row | Key Panels |
+|-----|------------|
+| Portfolio KPI Bar | Total request rate, error rate, P95 latency, active API count (stat) |
+| Traffic Trends | Request rate over time, traffic by API (timeseries) |
+| Error Analysis | Error rate by API, error type distribution |
+| API Leaderboards | Top 10 by traffic, P95 latency, error rate (bargauge) |
+| Multi-Tenancy View | Traffic by org, by tenant |
+| Consumer Identity | API key traffic, OAuth clients, portal app usage |
+| Service Level Objectives | Availability SLO gauge, latency SLO gauge, error budget remaining, burn rate 1h / 6h, P95 vs threshold |
+| Cache & Backend Intelligence | Cache hit rate, backend version distribution |
+
+### tyk-api-troubleshooting
+
+- **UID**: `tyk-api-troubleshooting`
+- **File**: `tyk-demo/tyk-api-troubleshooting.json`
+- **Variables**: `api_id` (single-select, no "All"), `tyk_gw_id` (multi), `trace_id` (textbox, default `*`)
+
+| Row | Key Panels |
+|-----|------------|
+| API Health KPIs | Request rate, error rate, P95 latency, cache hit rate (stat) |
+| Latency Attribution | Total/gateway/upstream latency breakdown (timeseries + pie) |
+| Error Analysis | Error rate over time, response flag distribution (panel link → Loki) |
+| Traffic Patterns | Traffic over time, traffic by gateway |
+| Upstream Health | URS flag isolation, backend version distribution |
+| Gateway Config State | APIs loaded, policies loaded for selected gateway |
+| Distributed Tracing via Tempo | Recent traces table, Error traces table |
+| Log Analysis | Access logs, error/warn logs, all logs with trace correlation (Loki) |
+
 ---
 
 ## 2. OTLP Metric Reference
@@ -94,7 +154,7 @@ Row 8 is a text/markdown explanation panel (no data panels). There is no standal
 
 | Prometheus Metric | Source | Key Labels |
 |---|---|---|
-| `tyk_requests_by_route_total` | metadata | `route`, `api_name`, `method`, `response_code` |
+| `tyk_requests_by_route_total` | metadata | `route`, `path`, `api_id`, `api_name`, `method`, `response_code` |
 | `tyk_requests_by_org_total` | metadata | `org_id`, `api_name`, `method` |
 | `tyk_requests_by_version_total` | metadata | `api_version`, `api_id`, `response_code` |
 | `tyk_requests_by_apikey_total` | session | `api_key_suffix`, `api_id` |
@@ -177,6 +237,26 @@ sum by(LABEL)(increase(METRIC{service_name=~"$service_name"}[$__range]))
 - `$__rate_interval` — use for `rate()` and `histogram_quantile()` (Grafana-calculated optimal window)
 - `$__range` — use for `increase()` in pie/bar charts showing totals over the selected time range
 
+### API name join (leaderboard bargauge panels)
+
+`tyk_requests_by_route_total` carries `api_id` (not `tyk_api_id`), so use `label_replace()` to rename it before the join. This pattern replaces raw UUID bar labels with human-readable API names.
+
+```promql
+topk(10,
+  METRIC_EXPR_grouped_by_tyk_api_id
+  * on(tyk_api_id) group_left(api_name)
+    label_replace(
+      max by(api_id, api_name)(tyk_requests_by_route_total{service_name=~"$service_name"}),
+      "tyk_api_id", "$1", "api_id", "(.*)"
+    )
+)
+```
+`legendFormat: "{{api_name}}"`
+
+Applied to: panels 22 & 33 (error rate), panel 32 (P95 latency) in `tyk-api-portfolio`. Panel 31 (request rate) already uses `tyk_requests_by_route_total` directly so only needs `legendFormat: "{{api_name}}"`.
+
+Note: `tyk_api_id` labels are preserved on the left side of the join, so drill-down links using `${__field.labels.tyk_api_id}` continue to work.
+
 ---
 
 ## 5. Design Workflow
@@ -198,6 +278,8 @@ mcp: update_dashboard(
   ]
 )
 ```
+
+> **Provisioned dashboards**: `update_dashboard` via MCP returns `"Cannot save provisioned dashboard"` for dashboards 2–4. All changes must be made directly to the JSON source files under `deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/`. JSONPath filter syntax (`$.panels[?(@.id==N)]`) is also unsupported — use array indices (`$.panels[N]`) instead.
 
 ### Add a new panel
 ```
@@ -264,6 +346,8 @@ mcp: query_prometheus(datasourceUid="prometheus", expr='{service_name="tyk-gatew
 | Context dimension panels always show default value | Middleware not setting context variables | Context vars need explicit middleware (Go plugin, virtual endpoint) |
 | `response_header` labels are empty/default on errors | Error path doesn't populate response headers | By design; use `"default"` to handle gracefully |
 | "Value" legend on Status Code Distribution (id=23) | `instant: true, format: "table"` ignores legendFormat | Add `"displayName": "Requests"` to `fieldConfig.defaults` |
+| Loki `count_over_time` metric query returns no data for gateway logs | `{service_name="tyk-gateway"}` matches 0 indexed streams — all logs share one stream, `service_name` is structured metadata (unindexed) | Use `{service_name=~".+"}` as stream selector, then `\| service_name="tyk-gateway"` as post-filter |
+| Loki metric bar chart shows gaps at wider time ranges | Hardcoded `[5m]` window in `count_over_time` — when Grafana step > 5m, buckets don't cover the full step | Replace `[5m]` with `[$__interval]` |
 
 ---
 
@@ -326,12 +410,242 @@ mcp: query_prometheus(datasourceUid="prometheus", expr='{service_name="tyk-gatew
 | Run a PromQL query | `query_prometheus` | `datasourceUid`, `expr`, `startTime`, `queryType` |
 | Browse metric names | `list_prometheus_metric_names` | `datasourceUid`, `regex` |
 | Check label values | `list_prometheus_label_values` | `datasourceUid`, `labelName` |
-| Dashboard overview | `get_dashboard_summary` | `uid="tyk-gateway-otlp-metrics"` |
-| See all panel queries | `get_dashboard_panel_queries` | `uid="tyk-gateway-otlp-metrics"` |
-| Get full dashboard JSON | `get_dashboard_by_uid` | `uid="tyk-gateway-otlp-metrics"` |
+| Dashboard overview | `get_dashboard_summary` | `uid=` any of: `tyk-gateway-otlp-metrics`, `tyk-gateway-fleet-health`, `tyk-api-portfolio`, `tyk-api-troubleshooting` |
+| See all panel queries | `get_dashboard_panel_queries` | `uid=` (any dashboard UID above) |
+| Get full dashboard JSON | `get_dashboard_by_uid` | `uid=` (any dashboard UID above) |
 | Query specific JSON paths | `get_dashboard_property` | `uid`, `jsonPath` (e.g. `$.panels[*].title`) |
 | Patch panel(s) | `update_dashboard` with `operations` | `uid`, array of patch ops with JSONPath |
 | Add a panel | `update_dashboard` | `op: "add", path: "$.panels/-"`, full panel JSON as `value` |
 | Render panel to PNG | `get_panel_image` | `dashboardUid`, `panelId` |
 | Create clickable panel link | `generate_deeplink` | `resourceType="panel"`, `dashboardUid`, `panelId` |
 | Search dashboards | `search_dashboards` | `query="tyk"` |
+| Find Loki datasource UID | `list_datasources` | `type="loki"` |
+| Query Loki logs | `query_loki_logs` | `datasourceUid`, `logql`, `startRfc3339` |
+| Find Tempo datasource UID | `list_datasources` | `type="tempo"` |
+
+---
+
+## 11. Fleet Health — Metrics & Queries
+
+### Key Prometheus Metrics (not in tyk-gateway-otlp-metrics)
+
+| Metric | Type | Key Labels |
+|--------|------|------------|
+| `tyk_gateway_apis_loaded` | gauge | `tyk_gw_id`, `tyk_gw_group_id` |
+| `tyk_gateway_policies_loaded` | gauge | `tyk_gw_id`, `tyk_gw_group_id` |
+| `tyk_gateway_config_reload_total` | counter | `tyk_gw_id` |
+| `tyk_gateway_config_reload_duration_seconds` | histogram | `tyk_gw_id` |
+| `go_memory_used_bytes` | gauge | `tyk_gw_id` |
+| `go_memory_gc_goal_bytes` | gauge | `tyk_gw_id` |
+| `go_memory_limit_bytes` | gauge | `tyk_gw_id` |
+| `go_goroutine_count` | gauge | `tyk_gw_id` |
+| `go_processor_limit` | gauge | `tyk_gw_id` |
+| `go_memory_allocated_bytes_total` | counter | `tyk_gw_id` |
+| `go_memory_allocations_total` | counter | `tyk_gw_id` |
+
+`tyk_http_requests_total` and `tyk_api_requests_total` also appear here with `tyk_gw_id` label for per-gateway traffic.
+
+### Key PromQL Patterns
+
+```promql
+# Config drift: difference in APIs loaded across gateways
+max(tyk_gateway_apis_loaded{tyk_gw_id=~"$tyk_gw_id"}) - min(tyk_gateway_apis_loaded{tyk_gw_id=~"$tyk_gw_id"})
+
+# Heap pressure (0–1 scale, > 0.8 is concerning)
+go_memory_used_bytes{tyk_gw_id=~"$tyk_gw_id"} / go_memory_limit_bytes{tyk_gw_id=~"$tyk_gw_id"}
+
+# Per-gateway request rate
+sum by(tyk_gw_id)(rate(tyk_http_requests_total{tyk_gw_id=~"$tyk_gw_id"}[$__rate_interval]))
+
+# Config reload rate
+rate(tyk_gateway_config_reload_total{tyk_gw_id=~"$tyk_gw_id"}[$__rate_interval])
+```
+
+### Loki Queries (Gateway Health Events row)
+
+```logql
+# Gateway error logs — log panel (full-scan, works fine with unindexed service_name)
+{service_name="tyk-gateway"} | detected_level=~`error|fatal`
+
+# Log volume metric query — count_over_time for timeseries bar chart (panel 61)
+# IMPORTANT: {service_name="tyk-gateway"} returns 0 indexed streams in this deployment.
+# detected_level is structured metadata (unindexed). Use the actual single indexed stream:
+sum(count_over_time({service_name=~".+"} | service_name="tyk-gateway" | detected_level="error" [$__interval]))
+# Use separate refIds per level (error/warn/info) for stacked bars with per-series color overrides.
+# Stacked bar config: drawStyle="bars", stacking={mode:"normal"}, fillOpacity=80
+
+# Upstream failures
+{service_name="tyk-gateway"} | tyk_prefix=`access-log` | tyk_response_flag=~`URS|UT|UH`
+```
+
+---
+
+## 12. API Portfolio — SLO Patterns & Variables
+
+### SLO Variables
+
+| Variable | Type | Options / Source |
+|----------|------|-----------------|
+| `slo_availability_target` | custom | `99,99.5,99.9,99.95,99.99` (default: 99.9) |
+| `slo_latency_ms` | custom | `200,500,1000,2000` (default: 500) |
+
+Both are used as raw numbers in PromQL via `$slo_availability_target` and `$slo_latency_ms`.
+
+### SLO PromQL Patterns
+
+```promql
+# Availability % (current window)
+(1 - (
+  sum(rate(tyk_api_requests_total{service_name=~"$service_name", http_response_status_code=~"5.."}[$__rate_interval]))
+  / sum(rate(tyk_api_requests_total{service_name=~"$service_name"}[$__rate_interval]))
+)) * 100
+
+# Error budget remaining % (30-day window)
+(1 - (
+  sum(increase(tyk_api_requests_total{service_name=~"$service_name", http_response_status_code=~"5.."}[30d]))
+  / sum(increase(tyk_api_requests_total{service_name=~"$service_name"}[30d]))
+)) / (1 - $slo_availability_target / 100) * 100
+
+# SLO burn rate — 1h (how fast error budget is consumed vs allowed)
+(
+  sum(rate(tyk_api_requests_total{service_name=~"$service_name", http_response_status_code=~"5.."}[1h]))
+  / sum(rate(tyk_api_requests_total{service_name=~"$service_name"}[1h]))
+) / (1 - $slo_availability_target / 100)
+
+# P95 latency vs SLO threshold (for gauge: green if <= $slo_latency_ms)
+histogram_quantile(0.95,
+  sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~"$service_name"}[$__rate_interval]))
+) * 1000
+```
+
+### Cross-Dashboard Links
+
+Panels in API Portfolio use `links` with URL templates to deep-link into API Troubleshooting:
+```
+/grafana/d/tyk-api-troubleshooting?var-api_id=${__data.fields.tyk_api_id}
+```
+This allows clicking an API row in a leaderboard to jump directly to that API's troubleshooting view.
+
+---
+
+## 13. API Troubleshooting — Tempo & Loki Patterns
+
+### Tempo Query Pattern (traceqlSearch)
+
+Both Tempo panels use `queryType: "traceqlSearch"` with structured filters:
+
+```
+# Recent traces for a specific API
+service.name = "tyk-gateway"    (resource scope)
+tyk.api.id = "$api_id"          (span scope)
+
+# Error traces only — add:
+status = error                   (intrinsic scope)
+```
+
+In Grafana panel JSON, these appear as `filters` objects in the `targets[].query` field:
+```json
+{
+  "filters": [
+    {"id": "...", "scope": "resource", "tag": "service.name", "operator": "=", "value": "tyk-gateway", "valueType": "string"},
+    {"id": "...", "scope": "span", "tag": "tyk.api.id", "operator": "=", "value": "$api_id", "valueType": "string"}
+  ]
+}
+```
+
+The `trace_id` variable (textbox, default `*`) is used to filter to a specific trace in the Log Analysis row — Loki panels include a `tyk_trace_id=~"$trace_id"` filter for drill-down correlation.
+
+### Loki Query Patterns
+
+```logql
+# API access logs for selected API
+{service_name="tyk-gateway"} | tyk_prefix=`access-log` | tyk_api_id=`$api_id`
+
+# Error and warning logs
+{service_name="tyk-gateway"} | detected_level=~`error|warn|fatal`
+
+# 5xx failures for selected API
+{service_name="tyk-gateway"} | tyk_prefix=`access-log` | tyk_api_id=`$api_id` | tyk_status=~`5..`
+
+# All logs with trace correlation (using trace_id variable)
+{service_name="tyk-gateway"} | tyk_api_id=`$api_id` | tyk_trace_id=~`$trace_id`
+```
+
+### Upstream Health — Response Flags
+
+The Upstream Health row isolates upstream-related response flags. Key flags used as filters:
+
+| Flag | Meaning |
+|------|---------|
+| `URS` | Upstream returned 5xx |
+| `UT` | Upstream timeout |
+| `UH` | No healthy upstream |
+| `BD` | Bad destination / connection refused |
+
+Pattern for isolating upstream failures:
+```promql
+sum by(tyk_response_flag)(
+  rate(http_server_request_duration_seconds_count{
+    service_name=~"$service_name",
+    tyk_api_id=~"$api_id",
+    tyk_response_flag=~"URS|UT|UH|BD"
+  }[$__rate_interval])
+)
+```
+
+---
+
+## 14. Dashboard Navigation (Cross-Links)
+
+Dashboards 2, 3, and 4 each carry a `links` array at the dashboard level (not panel level) that renders as clickable navigation buttons in the Grafana toolbar.
+
+### Structure (in dashboard JSON)
+
+```json
+"links": [
+  {
+    "title": "Fleet Health",
+    "type": "link",
+    "url": "/grafana/d/tyk-gateway-fleet-health",
+    "targetBlank": false,
+    "icon": "external link"
+  },
+  {
+    "title": "API Portfolio",
+    "type": "link",
+    "url": "/grafana/d/tyk-api-portfolio",
+    "targetBlank": false,
+    "icon": "external link"
+  },
+  {
+    "title": "API Troubleshooting",
+    "type": "link",
+    "url": "/grafana/d/tyk-api-troubleshooting",
+    "targetBlank": false,
+    "icon": "external link"
+  }
+]
+```
+
+Each dashboard omits its own UID from its `links` array (no self-links).
+
+### Inspect or modify nav links via MCP
+
+```
+mcp: get_dashboard_property(uid="tyk-gateway-fleet-health", jsonPath="$.links")
+mcp: update_dashboard(uid="tyk-gateway-fleet-health", operations=[
+  {"op": "replace", "path": "$.links[0].title", "value": "New Title"}
+])
+```
+
+### Adding nav links to tyk-gateway-otlp-metrics
+
+The OTLP metrics dashboard (in `tyk-demo-backup/`) does not currently have nav links. To add them:
+```
+mcp: update_dashboard(uid="tyk-gateway-otlp-metrics", operations=[
+  {"op": "add", "path": "$.links/-", "value": {
+    "title": "Fleet Health", "type": "link",
+    "url": "/grafana/d/tyk-gateway-fleet-health", "targetBlank": false, "icon": "external link"
+  }}
+])
+```

--- a/deployments/opentelemetry-demo/README.md
+++ b/deployments/opentelemetry-demo/README.md
@@ -246,6 +246,117 @@ PROMETHEUS_HOST=prometheus
 PROMETHEUS_ADDR=${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
 ```
 
+## Grafana Dashboards
+
+Grafana is available at **http://localhost:8085/grafana** (no login required).
+
+The deployment ships four pre-configured dashboards that together give a complete picture of Tyk Gateway in production. They cross-link to each other so you can navigate seamlessly during a demo.
+
+---
+
+### 1. Fleet Health — `tyk-gateway-fleet-health`
+
+**Who it's for**: Platform engineers and DevOps teams managing multiple gateway instances.
+
+**What it shows**:
+- How many gateway instances are running and how many APIs/policies each has loaded
+- Config drift — whether all gateways have the same number of APIs loaded (a sign of a sync problem)
+- Go runtime health: heap memory pressure, GC goal, goroutine count
+- Per-gateway request rate and traffic distribution
+- Gateway error log histogram (error / warn / info stacked bars, last N minutes)
+- Recent error log stream and upstream failure breakdown by API
+
+**Demo talking points**:
+- Open the Fleet Health dashboard and point out the KPI bar at the top — gateway count, total APIs loaded, fleet request rate.
+- Show the Config Drift gauge: if all gateways are in sync it reads 0. Explain this catches split-brain scenarios where a reload didn't propagate.
+- Scroll to Go Runtime Health — show heap pressure gauge. Explain this gives ops teams early warning before a gateway OOM-kills.
+- Show the log histogram at the bottom. This is Loki-backed — no log agent needed on the gateway side, just structured JSON logs over OTLP.
+
+---
+
+### 2. API Portfolio Overview — `tyk-api-portfolio`
+
+**Who it's for**: API platform leads and SRE on-call. The single-pane view across all APIs.
+
+**What it shows**:
+- Portfolio KPIs: total request rate, error rate, P95 latency, active API count
+- Traffic trends over time and per-API breakdown
+- Error analysis: error rate by API, error type distribution, top 10 APIs by error rate
+- API Leaderboards: top 10 APIs by traffic, P95 latency, and error rate — showing API names, not raw UUIDs
+- Multi-tenancy: traffic by organisation and tenant
+- Consumer identity: traffic by API key, OAuth client, developer portal app
+- SLO tracking: availability SLO gauge, error budget remaining, burn rate (1h and 6h), P95 latency vs threshold
+
+**Demo talking points**:
+- Start at the Portfolio KPI bar — these four numbers tell you the health of your entire API estate at a glance.
+- Scroll to the API Leaderboards. Point out that bar labels show API names. Clicking a bar links directly into the Troubleshooting dashboard for that API — no copy-pasting IDs.
+- Show the SLO section. Explain that `slo_availability_target` and `slo_latency_ms` are dashboard variables — you can change the target on the fly to model different SLO commitments.
+- Show the Multi-Tenancy and Consumer Identity rows. These come from Tyk's custom OTLP instruments and require no code changes in the upstream services — they're derived from request metadata, headers, and session context.
+
+**Filter interactions**: Clicking an API ID in the Latency by API table applies it as a dashboard filter, scoping all panels to that API.
+
+---
+
+### 3. API Troubleshooting — `tyk-api-troubleshooting`
+
+**Who it's for**: Backend engineers and SRE on-call investigating a specific API.
+
+**What it shows**:
+- API-scoped KPIs: request rate, error rate, P95 latency, cache hit rate
+- Latency attribution: how much of the end-to-end latency is the gateway vs the upstream
+- Error breakdown: error rate over time with response flag detail (e.g. `URS` = upstream 5xx, `UT` = upstream timeout)
+- Traffic patterns by gateway instance
+- Upstream health: isolation of upstream-related response flags
+- Distributed traces via Grafana Tempo: recent traces and error traces for the selected API
+- Structured log analysis: access logs, error/warn logs, all logs with trace ID correlation
+
+**Demo talking points**:
+- Select a specific API from the `api_id` variable at the top.
+- Show the Latency Attribution pie chart — it immediately answers "is the slowness in Tyk or in the backend?" without digging through logs.
+- Open the Distributed Tracing row. Click a trace row — it links to the full trace in Tempo showing every span across all microservices. This is end-to-end visibility from the gateway to the upstream service, all correlated by trace ID.
+- Show the Log Analysis row. Highlight the trace ID correlation: clicking a trace in Tempo gives you a trace ID, which you can paste into the `trace_id` variable to filter all log panels to that exact request.
+- For the error traces table, trigger a 5xx by toggling a feature flag (http://localhost:8085/feature/) then show the error appearing in real time.
+
+**Best entry point**: Arrive here from the API Portfolio Leaderboard by clicking "Troubleshoot this API" on any API bar.
+
+---
+
+### 4. Native OTLP Metrics Explorer — `tyk-gateway-otlp-metrics`
+
+**Who it's for**: Engineers and solution architects exploring what Tyk's custom OTLP instrumentation can produce.
+
+**What it shows**: All 19 OTLP instruments (4 default + 15 custom) across 13 rows covering traffic, latency, error analysis, method breakdown, and every available dimension source:
+- Metadata dimensions: route, API version, organisation, scheme
+- Session dimensions: API key (last 6 chars), OAuth client, developer portal app/org
+- Header dimensions: tenant ID (`X-Tenant-ID`), customer ID (`X-Customer-ID`)
+- Response header dimensions: cache status, backend version, content type
+- Context dimensions: subscription tier, region (requires middleware to populate)
+- Quota/rate-limit tracking via `X-RateLimit-Limit` response header
+
+**Demo talking points**:
+- This dashboard is the "what's possible" showcase. Open it after explaining that all these dimensions come for free from the gateway — no changes to upstream services.
+- Scroll through the rows and explain each dimension source type: metadata (built-in request fields), session (auth session data), headers (any request/response header), context (Tyk middleware-set variables).
+- Show the Session Dimensions row — API key traffic and OAuth client traffic are derived from Tyk's auth layer, zero instrumentation in application code.
+- The Context Dimensions row (tier, region) shows placeholder values by default because it needs middleware to set context variables. Explain this as a pattern for custom enrichment — a Go plugin can inject any value and it flows through to metrics automatically.
+
+---
+
+### Suggested Demo Flow
+
+For a **15-minute demo** to an audience unfamiliar with Tyk:
+
+1. **Fleet Health** (2 min) — "Here's how platform ops see the gateway fleet."
+2. **API Portfolio** (5 min) — "Here's the API estate view. Show SLOs, leaderboards, click through to troubleshooting."
+3. **API Troubleshooting** (5 min) — "Here's how an SRE investigates a specific API. Show latency attribution, then drill into a trace."
+4. **OTLP Metrics Explorer** (3 min) — "And here's everything you can measure out of the box, across 13 dimension categories."
+
+For a **deep-dive demo** focused on a specific persona:
+- **Platform ops**: Focus on Fleet Health — config drift, Go runtime, log histogram.
+- **API product manager**: Focus on Portfolio — SLOs, error budget, consumer identity rows.
+- **Backend engineer**: Focus on Troubleshooting — latency attribution + trace + log correlation.
+
+---
+
 ## Configuration
 
 This deployment demonstrates several key observability features:

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
@@ -2,10 +2,20 @@
   "uid": "tyk-api-portfolio",
   "title": "Tyk Gateway - API Portfolio Overview",
   "description": "Daily API health: RED metrics, error analysis, SLO tracking, multi-tenancy, and consumer identity. Audience: API platform team leads, SRE on-call.",
-  "tags": ["tyk", "api", "portfolio", "slo", "opentelemetry", "observability"],
+  "tags": [
+    "tyk",
+    "api",
+    "portfolio",
+    "slo",
+    "opentelemetry",
+    "observability"
+  ],
   "timezone": "browser",
   "refresh": "30s",
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "schemaVersion": 39,
   "version": 1,
   "templating": {
@@ -21,12 +31,18 @@
       {
         "name": "service_name",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_api_requests_total, service_name)",
         "label": "Service",
         "multi": false,
         "includeAll": false,
-        "current": { "text": "tyk-gateway", "value": "tyk-gateway" },
+        "current": {
+          "text": "tyk-gateway",
+          "value": "tyk-gateway"
+        },
         "refresh": 2,
         "sort": 1,
         "hide": 0
@@ -34,7 +50,10 @@
       {
         "name": "tyk_gw_group_id",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_gateway_apis_loaded, tyk_gw_group_id)",
         "label": "Group / Cluster",
         "multi": true,
@@ -48,7 +67,10 @@
       {
         "name": "tyk_gw_id",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_gateway_apis_loaded{tyk_gw_group_id=~\"$tyk_gw_group_id\"}, tyk_gw_id)",
         "label": "Gateway Node",
         "multi": true,
@@ -61,7 +83,10 @@
       {
         "name": "api_id",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, tyk_api_id)",
         "label": "API",
         "multi": true,
@@ -75,7 +100,10 @@
       {
         "name": "method",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, http_request_method)",
         "label": "Method",
         "multi": true,
@@ -89,23 +117,12 @@
       {
         "name": "org_id",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_requests_by_org_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, org_id)",
         "label": "Org",
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": {},
-        "refresh": 2,
-        "sort": 1,
-        "hide": 0
-      },
-      {
-        "name": "tenant_id",
-        "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-        "query": "label_values(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}, tenant_id)",
-        "label": "Tenant",
         "multi": true,
         "includeAll": true,
         "allValue": ".*",
@@ -119,13 +136,31 @@
         "type": "custom",
         "label": "Availability SLO (%)",
         "query": "99,99.5,99.9,99.95,99.99",
-        "current": { "text": "99.9", "value": "99.9" },
+        "current": {
+          "text": "99.9",
+          "value": "99.9"
+        },
         "options": [
-          { "text": "99", "value": "99" },
-          { "text": "99.5", "value": "99.5" },
-          { "text": "99.9", "value": "99.9" },
-          { "text": "99.95", "value": "99.95" },
-          { "text": "99.99", "value": "99.99" }
+          {
+            "text": "99",
+            "value": "99"
+          },
+          {
+            "text": "99.5",
+            "value": "99.5"
+          },
+          {
+            "text": "99.9",
+            "value": "99.9"
+          },
+          {
+            "text": "99.95",
+            "value": "99.95"
+          },
+          {
+            "text": "99.99",
+            "value": "99.99"
+          }
         ],
         "hide": 0,
         "multi": false,
@@ -136,12 +171,27 @@
         "type": "custom",
         "label": "Latency SLO (ms)",
         "query": "200,500,1000,2000",
-        "current": { "text": "500", "value": "500" },
+        "current": {
+          "text": "500",
+          "value": "500"
+        },
         "options": [
-          { "text": "200", "value": "200" },
-          { "text": "500", "value": "500" },
-          { "text": "1000", "value": "1000" },
-          { "text": "2000", "value": "2000" }
+          {
+            "text": "200",
+            "value": "200"
+          },
+          {
+            "text": "500",
+            "value": "500"
+          },
+          {
+            "text": "1000",
+            "value": "1000"
+          },
+          {
+            "text": "2000",
+            "value": "2000"
+          }
         ],
         "hide": 0,
         "multi": false,
@@ -151,436 +201,1743 @@
   },
   "panels": [
     {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9003,
+      "panels": [
+        {
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 9004,
+          "options": {
+            "content": "## \ud83d\uddfa How to use this dashboard\n\n**Target audience**: On-call SRE, API Platform Team Leads  \n**Use when**: Daily health check, on-call triage, SLO review\n\n| Symptom | What to look at | Next step |\n|---------|----------------|-----------|\n| \ud83d\udd34 Error rate elevated | Error Analysis row (top of page) | Click the API name \u2192 Troubleshoot |\n| \ud83d\udfe0 Error budget <20% remaining | SLO / Error Budget row | Incident likely in progress \u2014 escalate |\n| \ud83d\udd34 Latency regression | \"Top 10 APIs by P95 Latency\" | Click the API name \u2192 Troubleshoot |\n| \ud83d\udfe0 One tenant impacted | Multi-Tenancy row | Filter by `tenant_id` variable |\n| \ud83d\udd34 Gateway infra issue | Everything looks red | Check \u2192 [Fleet Health](/grafana/d/tyk-gateway-fleet-health) first |",
+            "mode": "markdown"
+          },
+          "title": "How to use this dashboard",
+          "type": "text"
+        }
+      ],
+      "title": "\u2139\ufe0f How to use this dashboard",
+      "type": "row"
+    },
+    {
       "id": 100,
       "type": "row",
       "title": "Portfolio KPI Bar",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 1,
       "type": "stat",
       "title": "Request Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 2,
       "type": "stat",
       "title": "5xx Error Rate",
       "description": "Server errors as % of total. Green <1%, Amber 1-5%, Red >5%.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 4, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 2,
+        "w": 3,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 3,
       "type": "stat",
       "title": "4xx Error Rate",
       "description": "Client errors as % of total. Green <5%, Amber 5-15%, Red >15%.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 7, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 5 }, { "color": "red", "value": 15 }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 7,
+        "y": 2,
+        "w": 3,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100 or vector(0)",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 4,
       "type": "stat",
       "title": "P95 Total Latency",
       "description": "End-to-end P95 latency seen by clients. Green <500ms, Amber 500-1000ms, Red >1s.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 10, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 1000 }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 10,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 5,
       "type": "stat",
       "title": "P95 Gateway Latency",
       "description": "Tyk's own processing overhead at P95. High value indicates policy execution or plugin issues.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 14, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 300 }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 14,
+        "y": 2,
+        "w": 3,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 6,
       "type": "stat",
       "title": "P95 Upstream Latency",
       "description": "Backend service P95 latency. High value = backend is slow, not Tyk.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 17, "y": 1, "w": 3, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 1000 }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 17,
+        "y": 2,
+        "w": 3,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 7,
       "type": "stat",
       "title": "Active APIs",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "refId": "A", "expr": "count(count by(tyk_api_id)(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}))", "instant": true }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } } }
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(count by(tyk_api_id)(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\"}))",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 200,
       "type": "row",
       "title": "Traffic Trends",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 11,
       "type": "timeseries",
       "title": "Request Rate by Status Class",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 6, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 7,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"2..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "2xx" },
-        { "refId": "B", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"3..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "3xx" },
-        { "refId": "C", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "4xx" },
-        { "refId": "D", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "5xx" }
+        {
+          "refId": "A",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"2..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "2xx"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"3..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "3xx"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"4..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "4xx"
+        },
+        {
+          "refId": "D",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "5xx"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 12,
       "type": "timeseries",
       "title": "Top 10 APIs by Traffic",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 6, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 7,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}" }
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by(api_name)(rate(tyk_requests_by_route_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", method=~\"$method\"}[$__rate_interval])))",
+          "legendFormat": "{{api_name}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 13,
       "type": "timeseries",
       "title": "Latency Trend: Total vs Gateway vs Upstream (P95)",
-      "description": "The hero panel. If gateway latency is flat and upstream spikes, the backend is the culprit — 5-second diagnosis.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 6, "w": 8, "h": 8 },
+      "description": "The hero panel. If gateway latency is flat and upstream spikes, the backend is the culprit \u2014 5-second diagnosis.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 7,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Total P95" },
-        { "refId": "B", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Gateway P95" },
-        { "refId": "C", "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "Upstream P95" }
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "Total P95"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "Gateway P95"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "Upstream P95"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "lineWidth": 2, "fillOpacity": 8 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 300,
       "type": "row",
       "title": "Error Analysis",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 21,
       "type": "timeseries",
       "title": "Error Rate by API",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 15, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100", "legendFormat": "{{tyk_api_id}}" }
+        {
+          "refId": "A",
+          "expr": "(\n  sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n  / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n  * 100\n)\n* on(tyk_api_id) group_left(api_name)\n  label_replace(\n    max by(api_id, api_name)(tyk_requests_by_route_total{service_name=~\"$service_name\"}),\n    \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n  )",
+          "legendFormat": "{{api_name}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "links": [
+            {
+              "title": "\ud83d\udd0d Troubleshoot this API",
+              "url": "/grafana/d/tyk-api-troubleshooting?${__url.params}&var-api_id=${__field.labels.tyk_api_id}",
+              "targetBlank": false
+            }
+          ]
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 22,
       "type": "bargauge",
       "title": "Top 10 APIs by Error Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 15, "w": 6, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 6,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100)", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10,\n  (\n    sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    * 100\n  )\n  * on(tyk_api_id) group_left(api_name)\n    label_replace(\n      max by(api_id, api_name)(tyk_requests_by_route_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    )\n)",
+          "legendFormat": "{{api_name}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "color": { "mode": "continuous-RdYlGr" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "links": [
+            {
+              "title": "\ud83d\udd0d Troubleshoot this API",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}&from=${__from}&to=${__to}",
+              "targetBlank": false
+            }
+          ]
+        }
+      }
     },
     {
       "id": 23,
       "type": "piechart",
       "title": "Response Flag Distribution",
       "description": "URS = upstream 5xx, BD = bad destination, RL = rate limited, AUTH = auth failure. Fastest path to error cause.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 14, "y": 15, "w": 5, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 14,
+        "y": 16,
+        "w": 5,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(tyk_response_flag)(increase(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range]))", "legendFormat": "{{tyk_response_flag}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(tyk_response_flag)(increase(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range]))",
+          "legendFormat": "{{tyk_response_flag}}"
+        }
       ],
-      "options": { "pieType": "donut", "displayLabels": ["percent", "name"], "legend": { "displayMode": "list", "placement": "bottom" } },
-      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "pieType": "donut",
+        "displayLabels": [
+          "percent",
+          "name"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 24,
       "type": "barchart",
       "title": "Status Code Distribution",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 19, "y": 15, "w": 5, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 19,
+        "y": 16,
+        "w": 5,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sort_desc(sum by(http_response_status_code)(increase(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range])))", "legendFormat": "{{http_response_status_code}}", "instant": true, "format": "table" }
+        {
+          "refId": "A",
+          "expr": "sort_desc(sum by(http_response_status_code)(increase(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__range])))",
+          "legendFormat": "{{http_response_status_code}}",
+          "instant": true,
+          "format": "table"
+        }
       ],
-      "options": { "xField": "http_response_status_code", "orientation": "vertical" },
-      "fieldConfig": { "defaults": { "unit": "short", "displayName": "Requests", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "xField": "http_response_status_code",
+        "orientation": "vertical"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "displayName": "Requests",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 25,
       "type": "timeseries",
       "title": "429 Rate Over Time",
-      "description": "Rate limiting pressure — leading indicator of customer impact.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 23, "w": 12, "h": 7 },
+      "description": "Rate limiting pressure \u2014 leading indicator of customer impact.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{tyk_api_id}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "{{tyk_api_id}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 26,
       "type": "bargauge",
       "title": "Top APIs by 429 Rejections",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 23, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 24,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=\"429\", tyk_api_id=~\"$api_id\"}[$__rate_interval])))",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 400,
       "type": "row",
       "title": "API Leaderboards",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 30, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 31,
       "type": "bargauge",
       "title": "Top 10 APIs by Request Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 31, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])))", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by(api_id, api_name)(rate(tyk_requests_by_route_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", http_method=~\"$method\"}[$__rate_interval])))",
+          "legendFormat": "{{api_name}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "continuous-BlYlRd" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "links": [
+            {
+              "title": "\ud83d\udd0d Troubleshoot this API",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.api_id}&from=${__from}&to=${__to}",
+              "targetBlank": false
+            }
+          ]
+        }
+      }
     },
     {
       "id": 32,
       "type": "bargauge",
       "title": "Top 10 APIs by P95 Latency",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 31, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000)", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10,\n  histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000\n  * on(tyk_api_id) group_left(api_name)\n    label_replace(\n      max by(api_id, api_name)(tyk_requests_by_route_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    )\n)",
+          "legendFormat": "{{api_name}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "continuous-GrYlRd" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "links": [
+            {
+              "title": "\ud83d\udd0d Troubleshoot this API",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}&from=${__from}&to=${__to}",
+              "targetBlank": false
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 33,
       "type": "bargauge",
       "title": "Top 10 APIs by Error Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 31, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 37,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval])) * 100)", "legendFormat": "{{tyk_api_id}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10,\n  (\n    sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    * 100\n  )\n  * on(tyk_api_id) group_left(api_name)\n    label_replace(\n      max by(api_id, api_name)(tyk_requests_by_route_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    )\n)",
+          "legendFormat": "{{api_name}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "color": { "mode": "continuous-RdYlGr" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "links": [
+            {
+              "title": "\ud83d\udd0d Troubleshoot this API",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}&from=${__from}&to=${__to}",
+              "targetBlank": false
+            }
+          ]
+        }
+      }
     },
     {
       "id": 34,
       "type": "table",
-      "title": "Latency by API (P50 / P95 / P99) — Total, Gateway, Upstream",
+      "title": "Latency by API (P50 / P95 / P99) \u2014 Total, Gateway, Upstream",
       "description": "Full percentile breakdown. Starting point for investigation into a slow or error-prone API.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 39, "w": 24, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 24,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.50, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "B", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "C", "expr": "histogram_quantile(0.99, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "D", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "E", "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" },
-        { "refId": "F", "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))", "legendFormat": "{{tyk_api_id}}", "instant": true, "format": "table" }
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by(le, tyk_api_id)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "refId": "D",
+          "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "refId": "E",
+          "expr": "histogram_quantile(0.95, sum by(le, tyk_api_id)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "refId": "F",
+          "expr": "sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "{{tyk_api_id}}",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "refId": "G",
+          "expr": "sum by(tyk_api_id, api_name)(label_replace(tyk_requests_by_route_total{service_name=~\"$service_name\"},\"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"))",
+          "legendFormat": "{{api_name}}",
+          "instant": true,
+          "format": "table"
+        }
       ],
-      "options": { "sortBy": [{ "displayName": "Total P95 (ms)", "desc": true }] },
+      "options": {
+        "sortBy": [
+          {
+            "displayName": "Total P95 (ms)",
+            "desc": true
+          }
+        ]
+      },
       "transformations": [
-        { "id": "merge", "options": {} },
-        { "id": "organize", "options": { "renameByName": { "Value #A": "Total P50 (ms)", "Value #B": "Total P95 (ms)", "Value #C": "Total P99 (ms)", "Value #D": "Gateway P95 (ms)", "Value #E": "Upstream P95 (ms)", "Value #F": "Req/s", "tyk_api_id": "API" } } }
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "Total P50 (ms)",
+              "Value #B": "Total P95 (ms)",
+              "Value #C": "Total P99 (ms)",
+              "Value #D": "Gateway P95 (ms)",
+              "Value #E": "Upstream P95 (ms)",
+              "Value #F": "Req/s",
+              "tyk_api_id": "api_id",
+              "api_name": "API Name",
+              "Value #G": ""
+            },
+            "excludeByName": {
+              "Value #G": true
+            }
+          }
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [{ "matcher": { "id": "byName", "options": "Req/s" }, "properties": [{ "id": "unit", "value": "reqps" }] }] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "nan",
+                "result": {
+                  "text": "\u2014",
+                  "color": "text"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Req/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "api_id"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "\ud83d\udd0d Troubleshoot this API",
+                    "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__value.text}&${__url.params}",
+                    "targetBlank": false
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
     },
     {
       "id": 500,
       "type": "row",
       "title": "Multi-Tenancy View",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 47, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 53,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 41,
       "type": "timeseries",
       "title": "Traffic by Organisation",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 48, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 54,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(org_id)(rate(tyk_requests_by_org_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", org_id=~\"$org_id\", method=~\"$method\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{org_id}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(org_id)(rate(tyk_requests_by_org_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", org_id=~\"$org_id\", method=~\"$method\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "{{org_id}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 42,
       "type": "timeseries",
       "title": "Per-Tenant Request Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 48, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 54,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{tenant_id}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "{{tenant_id}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 43,
       "type": "timeseries",
       "title": "Tenant Error Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 48, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 54,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", response_code=~\"5..\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tenant_id=~\"$tenant_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100", "legendFormat": "{{tenant_id}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", response_code=~\"5..\", api_id=~\"$api_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100",
+          "legendFormat": "{{tenant_id}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 44,
       "type": "table",
       "title": "Tenant SLO Table",
       "description": "Per-tenant: request rate, error %, P50 latency, P95 latency. Mini SLO view at a glance.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 55, "w": 16, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 61,
+        "w": 16,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
-        { "refId": "B", "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", response_code=~\"5..\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval])) * 100", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
-        { "refId": "C", "expr": "histogram_quantile(0.50, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))) * 1000", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" },
-        { "refId": "D", "expr": "histogram_quantile(0.95, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\", tenant_id=~\"$tenant_id\"}[$__rate_interval]))) * 1000", "instant": true, "format": "table", "legendFormat": "{{tenant_id}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "{{tenant_id}}"
+        },
+        {
+          "refId": "B",
+          "expr": "sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", response_code=~\"5..\", api_id=~\"$api_id\"}[$__rate_interval])) / sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "{{tenant_id}}"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.50, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))) * 1000",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "{{tenant_id}}"
+        },
+        {
+          "refId": "D",
+          "expr": "histogram_quantile(0.95, sum by(le, tenant_id)(rate(tyk_latency_by_tenant_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))) * 1000",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "{{tenant_id}}"
+        }
       ],
       "transformations": [
-        { "id": "merge", "options": {} },
-        { "id": "organize", "options": { "renameByName": { "tenant_id": "Tenant", "Value #A": "Req/s", "Value #B": "5xx %", "Value #C": "P50 (ms)", "Value #D": "P95 (ms)" } } }
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "tenant_id": "Tenant",
+              "Value #A": "Req/s",
+              "Value #B": "5xx %",
+              "Value #C": "P50 (ms)",
+              "Value #D": "P95 (ms)"
+            }
+          }
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [{ "matcher": { "id": "byName", "options": "Req/s" }, "properties": [{ "id": "unit", "value": "reqps" }] }, { "matcher": { "id": "byName", "options": "5xx %" }, "properties": [{ "id": "unit", "value": "percent" }, { "id": "custom.displayMode", "value": "color-background" }, { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] } }] }] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "nan",
+                "result": {
+                  "text": "\u2014",
+                  "color": "text"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Req/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
     },
     {
       "id": 45,
       "type": "bargauge",
       "title": "Top Tenants by Traffic",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 55, "w": 8, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 61,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "{{tenant_id}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by(tenant_id)(rate(tyk_requests_by_tenant_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 600,
       "type": "row",
       "title": "Consumer Identity",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 63, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 69,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 51,
       "type": "timeseries",
       "title": "API Key Traffic Over Time",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 64, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 70,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "...{{api_key_suffix}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "...{{api_key_suffix}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 52,
       "type": "bargauge",
       "title": "Top API Keys by Traffic",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 64, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 70,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "topk(10, sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])))", "legendFormat": "...{{api_key_suffix}}", "instant": true }
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by(api_key_suffix)(rate(tyk_requests_by_apikey_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])))",
+          "legendFormat": "...{{api_key_suffix}}",
+          "instant": true
+        }
       ],
-      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 53,
       "type": "timeseries",
       "title": "OAuth Client Traffic",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 64, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 70,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(oauth_client_id)(rate(tyk_requests_by_oauth_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{oauth_client_id}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(oauth_client_id)(rate(tyk_requests_by_oauth_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "{{oauth_client_id}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 54,
       "type": "piechart",
       "title": "Portal App Usage Share",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 71, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 77,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(portal_app)(increase(tyk_requests_by_portal_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__range]))", "legendFormat": "{{portal_app}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(portal_app)(increase(tyk_requests_by_portal_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__range]))",
+          "legendFormat": "{{portal_app}}"
+        }
       ],
-      "options": { "pieType": "pie", "displayLabels": ["percent", "name"], "legend": { "displayMode": "list", "placement": "right" } },
-      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "pieType": "pie",
+        "displayLabels": [
+          "percent",
+          "name"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 55,
       "type": "timeseries",
       "title": "Subscription Tier Traffic",
       "description": "Free vs Pro vs Enterprise traffic split.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 71, "w": 16, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 77,
+        "w": 16,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(subscription_tier)(rate(tyk_requests_by_tier_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "{{subscription_tier}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(subscription_tier)(rate(tyk_requests_by_tier_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "{{subscription_tier}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 700,
       "type": "row",
       "title": "Service Level Objectives",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 78, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 84,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
@@ -588,124 +1945,557 @@
       "type": "gauge",
       "title": "Availability SLO",
       "description": "1 - (5xx rate / total rate). Target: $slo_availability_target%.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 79, "w": 6, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 85,
+        "w": 6,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "(1 - sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))) * 100 or vector(100)", "instant": true }
+        {
+          "refId": "A",
+          "expr": "(1 - sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[$__rate_interval]))) * 100 or vector(100)",
+          "instant": true
+        }
       ],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "showThresholdLabels": true, "showThresholdMarkers": true },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 95, "max": 100, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 99 }, { "color": "green", "value": 99.9 }] } } }
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 95,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 62,
       "type": "gauge",
       "title": "Latency SLO",
       "description": "% of requests completing within $slo_latency_ms ms.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 6, "y": 79, "w": 6, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 85,
+        "w": 6,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", le=\"1\"}[$__rate_interval])) / sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(100)", "instant": true }
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", le=\"1\"}[$__rate_interval])) / sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(100)",
+          "instant": true
+        }
       ],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "showThresholdLabels": true, "showThresholdMarkers": true },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 80, "max": 100, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 90 }, { "color": "green", "value": 99 }] } } }
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 80,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 63,
       "type": "stat",
       "title": "Error Budget Remaining",
       "description": "30-day rolling error budget. Budget consumed = actual error rate / allowed error rate (0.1% for 99.9% SLO). Turns red when budget is burning fast.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 79, "w": 4, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 85,
+        "w": 4,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "(1 - (sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[30d])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[30d]))) / (1 - $slo_availability_target/100)) * 100 or vector(100)", "instant": true }
+        {
+          "refId": "A",
+          "expr": "(1 - (sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[30d])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[30d]))) / (1 - $slo_availability_target/100)) * 100 or vector(100)",
+          "instant": true
+        }
       ],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 25 }, { "color": "green", "value": 50 }] } } }
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 64,
       "type": "timeseries",
       "title": "SLO Burn Rate (1h and 6h windows)",
-      "description": ">14.4× on 1h window = burns 100% of monthly budget in 1h = critical page.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 79, "w": 8, "h": 8 },
+      "description": ">14.4\u00d7 on 1h window = burns 100% of monthly budget in 1h = critical page.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 85,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[1h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[1h])) / (1 - $slo_availability_target/100) or vector(0)", "legendFormat": "1h burn rate" },
-        { "refId": "B", "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[6h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[6h])) / (1 - $slo_availability_target/100) or vector(0)", "legendFormat": "6h burn rate" }
+        {
+          "refId": "A",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[1h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[1h])) / (1 - $slo_availability_target/100) or vector(0)",
+          "legendFormat": "1h burn rate"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\"}[6h])) / sum(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\"}[6h])) / (1 - $slo_availability_target/100) or vector(0)",
+          "legendFormat": "6h burn rate"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 14.4 }] } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 14.4
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 65,
       "type": "timeseries",
       "title": "P95 Latency vs SLO Threshold",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 87, "w": 24, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 93,
+        "w": 24,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000", "legendFormat": "P95 Total Latency" },
-        { "refId": "B", "expr": "$slo_latency_ms + 0", "legendFormat": "SLO Threshold (${slo_latency_ms}ms)" }
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))) * 1000",
+          "legendFormat": "P95 Total Latency"
+        },
+        {
+          "refId": "B",
+          "expr": "$slo_latency_ms + 0",
+          "legendFormat": "SLO Threshold (${slo_latency_ms}ms)"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "lineWidth": 2, "fillOpacity": 8 } }, "overrides": [{ "matcher": { "id": "byName", "options": "SLO Threshold (${slo_latency_ms}ms)" }, "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }, { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }] },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLO Threshold (${slo_latency_ms}ms)"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 800,
       "type": "row",
       "title": "Cache & Backend Intelligence",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 94, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 100,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
       "id": 71,
       "type": "stat",
       "title": "Cache Hit Rate",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 95, "w": 4, "h": 4 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 101,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
-        { "refId": "A", "expr": "sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", cache_status=\"1\", api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(0)", "instant": true }
+        {
+          "refId": "A",
+          "expr": "sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", cache_status=\"1\", api_id=~\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])) * 100 or vector(0)",
+          "instant": true
+        }
       ],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "auto" },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 40 }, { "color": "green", "value": 70 }] } } }
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 40
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "id": 72,
       "type": "timeseries",
       "title": "Cache Status Over Time",
       "description": "Drop in cache hits often precedes latency spikes.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 4, "y": 95, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 101,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(cache_status)(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))", "legendFormat": "cache={{cache_status}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(cache_status)(rate(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "cache={{cache_status}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
     },
     {
       "id": 73,
       "type": "piechart",
       "title": "Cache Status Breakdown",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 95, "w": 6, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 101,
+        "w": 6,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by(cache_status)(increase(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__range]))", "legendFormat": "cache={{cache_status}}" }
+        {
+          "refId": "A",
+          "expr": "sum by(cache_status)(increase(tyk_requests_with_cache_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__range]))",
+          "legendFormat": "cache={{cache_status}}"
+        }
       ],
-      "options": { "pieType": "donut", "displayLabels": ["percent", "name"], "legend": { "displayMode": "list", "placement": "right" } },
-      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
+      "options": {
+        "pieType": "donut",
+        "displayLabels": [
+          "percent",
+          "name"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
     },
     {
       "id": 74,
       "type": "timeseries",
       "title": "Backend Version Distribution",
-      "description": "Canary and blue-green rollout visibility — correlate latency with version changes.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 18, "y": 95, "w": 6, "h": 7 },
+      "description": "Canary and blue-green rollout visibility \u2014 correlate latency with version changes.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 101,
+        "w": 6,
+        "h": 7
+      },
       "targets": [
-        { "refId": "A", "expr": "label_replace(sum by(backend_version)(rate(tyk_requests_by_backend_version_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])), \"backend_version\", \"No version\", \"backend_version\", \"^$\")", "legendFormat": "{{backend_version}}" }
+        {
+          "refId": "A",
+          "expr": "label_replace(sum by(backend_version)(rate(tyk_requests_by_backend_version_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", api_id=~\"$api_id\"}[$__rate_interval])), \"backend_version\", \"No version\", \"backend_version\", \"^$\")",
+          "legendFormat": "{{backend_version}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 9006,
+      "panels": [],
+      "title": "Tyk Response Flag Reference",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 9005,
+      "options": {
+        "content": "[Error classification docs \u2192](https://tyk.io/docs/api-management/logs#error-classification)\n\n**Upstream and Proxy Errors**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `TLE` | TLS Certificate Expired | 502 | Upstream TLS certificate has expired |\n| `TLI` | TLS Certificate Invalid | 502 | Upstream TLS certificate failed validation |\n| `TLM` | TLS Hostname Mismatch | 502 | Certificate CN/SAN does not match hostname |\n| `TLN` | TLS Not Trusted | 502 | Certificate issued by unknown authority |\n| `TLH` | TLS Handshake Failure | 502 | TLS handshake failed |\n| `TLP` | TLS Protocol Error | 502 | TLS protocol or version mismatch |\n| `TLA` | TLS Alert | 502 | TLS alert received from upstream |\n| `UCF` | Connection Refused | 502 | Upstream refused the TCP connection |\n| `UCT` | Connection Timeout | 502 | TCP connection to upstream timed out |\n| `URR` | Connection Reset | 502 | Connection reset by upstream server |\n| `EPI` | Broken Pipe | 502 | Connection closed unexpectedly (EPIPE) |\n| `URT` | Response Timeout | 504 | Upstream did not respond in time |\n| `DNS` | DNS Resolution Failure | 502 | Upstream hostname could not be resolved |\n| `NRH` | No Route to Host | 502 | Upstream host or network unreachable |\n| `NHU` | No Healthy Upstreams | 503 | All targets in load balancer are unhealthy |\n| `CBO` | Circuit Breaker Open | 503 | Circuit breaker is open |\n| `URS` | Upstream Response 5XX | 5XX | Upstream returned a 5XX status code |\n| `UPE` | Upstream Error | 5XX | Generic upstream error |\n\n**Authentication Errors**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `AMF` | Auth Field Missing | 400/401 | Authorization header or parameter missing |\n| `AKI` | API Key Invalid | 403 | API key not found or invalid |\n| `TKE` | Token Expired | 403 | JWT, OAuth token, or client cert has expired |\n| `TKI` | Token Invalid | 403 | JWT or OAuth token malformed or bad signature |\n| `TCV` | Token Claims Invalid | 401 | JWT claims validation failed |\n| `EAD` | External Auth Denied | 403 | External auth service denied the request |\n\n**Rate Limiting**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `RLT` | Rate Limited | 429 | Request rejected due to rate limit |\n| `QEX` | Quota Exceeded | 403 | Client usage quota exhausted |\n\n**Request Validation**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `BTL` | Body Too Large | 400 | Request body exceeds configured size limit |\n| `CLM` | Content-Length Missing | 411 | Required Content-Length header missing |\n| `BIV` | Body Invalid | 400/422 | Request body malformed or fails schema validation |\n| `IHD` | Invalid Header | 400 | Required request header malformed or invalid |\n\n**Client Connection**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `CDC` | Client Disconnected | 499 | Client closed connection before response sent |",
+        "mode": "markdown"
+      },
+      "title": "Tyk Response Flag Reference",
+      "type": "text"
+    }
+  ],
+  "links": [
+    {
+      "title": "\ud83d\udda5 Fleet Health",
+      "url": "/grafana/d/tyk-gateway-fleet-health",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "\ud83d\udcca API Portfolio",
+      "url": "/grafana/d/tyk-api-portfolio",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "\ud83d\udd0d API Troubleshooting",
+      "url": "/grafana/d/tyk-api-troubleshooting",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
     }
   ]
 }

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-troubleshooting.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-troubleshooting.json
@@ -1,7 +1,7 @@
 {
   "uid": "tyk-api-troubleshooting",
   "title": "Tyk Gateway - API Troubleshooting",
-  "description": "Single-API deep dive: metrics \u2192 traces \u2192 logs. Progressive disclosure from symptom to root cause. Audience: Backend engineers, SRE on-call.",
+  "description": "Single-API deep dive: metrics → traces → logs. Progressive disclosure from symptom to root cause. Audience: Backend engineers, SRE on-call.",
   "tags": [
     "tyk",
     "api",
@@ -81,10 +81,10 @@
         "name": "trace_id",
         "type": "textbox",
         "label": "Trace ID",
-        "query": "",
+        "query": ".*",
         "current": {
-          "text": "*",
-          "value": "*"
+          "text": ".*",
+          "value": ".*"
         },
         "hide": 0
       }
@@ -92,25 +92,37 @@
   },
   "panels": [
     {
-      "id": 1,
-      "type": "text",
-      "title": "Troubleshooting Decision Tree",
-      "description": "Collapsible guide \u2014 start here if you're not sure which row to look at.",
+      "collapsed": true,
       "gridPos": {
-        "x": 0,
-        "y": 0,
+        "h": 1,
         "w": 24,
-        "h": 7
+        "x": 0,
+        "y": 0
       },
-      "collapsed": false,
-      "options": {
-        "mode": "markdown",
-        "content": "## Troubleshooting Guide \u2014 Start Here\n\n| Symptom | Where to look | What to check |\n|---------|--------------|---------------|\n| **Elevated error rate** | Row 3 (Error Analysis) | Response Flag: `URS` = upstream 5xx \u2192 Row 5; `BD` = bad destination \u2192 DNS/proxy config; `AUTH` = auth middleware; `RL` = rate limit |\n| **Latency spike** | Row 2 (Latency Attribution) | Gateway latency high \u2192 Tyk issue (Go plugin? policy?); Upstream latency high \u2192 backend degraded \u2192 Row 5 |\n| **Traffic drop, no errors** | Row 1 (check req rate) + Row 6 (Gateway Config) | API count dropped on a node? \u2192 deployment issue \u2192 use Fleet Health dashboard |\n| **Cache hit rate suddenly low** | Row 1 (Cache Hit Rate stat) | Row 8 Logs \u2192 filter `cache_hit=false` \u2192 correlate with latency spike time |\n| **Need to inspect a specific failing request** | Row 7 (Traces) | Click slowest/error trace \u2192 copy `trace_id` \u2192 paste into `$trace_id` variable \u2192 Row 8 filters to that request; click Trace ID link to open in Tempo |"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      }
+      "id": 9007,
+      "panels": [
+        {
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 1,
+          "options": {
+            "content": "## 🗺 How to use this dashboard\n\n**Target audience**: Backend engineers, on-call SREs  \n**Use when**: Investigating a specific API incident\n\n**Step 1**: Set `api_id` variable (top of page) to the API under investigation  \n**Step 2**: Set time range to the incident window  \n**Step 3**: Follow the signal chain:\n\n1. **Latency spike?** → Latency Attribution row → Is it Gateway overhead or Upstream slowness?\n   - Gateway overhead → check middleware config, rate limiting, auth plugin\n   - Upstream slowness → upstream service issue, not Tyk\n2. **Error spike?** → Error Analysis row → What status codes? What response flags?\n   - `AKI` = auth key invalid | `URS` = upstream 5xx | `BD` = bad destination | `RL` = rate limited\n3. **Need the trace?** → Click a dot on the latency chart → Tempo trace opens\n4. **Need the logs?** → Click \"View gateway logs\" on any error panel → Loki",
+            "mode": "markdown"
+          },
+          "title": "How to use this dashboard",
+          "type": "text"
+        }
+      ],
+      "title": "ℹ️ How to use this dashboard",
+      "type": "row"
     },
     {
       "id": 100,
@@ -119,7 +131,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 7,
+        "y": 1,
         "w": 24,
         "h": 1
       },
@@ -135,7 +147,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 8,
+        "y": 2,
         "w": 4,
         "h": 4
       },
@@ -184,7 +196,7 @@
       },
       "gridPos": {
         "x": 4,
-        "y": 8,
+        "y": 2,
         "w": 3,
         "h": 4
       },
@@ -243,7 +255,7 @@
       },
       "gridPos": {
         "x": 7,
-        "y": 8,
+        "y": 2,
         "w": 3,
         "h": 4
       },
@@ -279,11 +291,11 @@
               },
               {
                 "color": "yellow",
-                "value": 500
+                "value": 200
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 500
               }
             ]
           }
@@ -301,7 +313,7 @@
       },
       "gridPos": {
         "x": 10,
-        "y": 8,
+        "y": 2,
         "w": 3,
         "h": 4
       },
@@ -337,11 +349,11 @@
               },
               {
                 "color": "yellow",
-                "value": 100
+                "value": 200
               },
               {
                 "color": "red",
-                "value": 300
+                "value": 500
               }
             ]
           }
@@ -359,7 +371,7 @@
       },
       "gridPos": {
         "x": 13,
-        "y": 8,
+        "y": 2,
         "w": 3,
         "h": 4
       },
@@ -395,11 +407,11 @@
               },
               {
                 "color": "yellow",
-                "value": 500
+                "value": 200
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 500
               }
             ]
           }
@@ -416,7 +428,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 8,
+        "y": 2,
         "w": 4,
         "h": 4
       },
@@ -475,14 +487,14 @@
       },
       "gridPos": {
         "x": 20,
-        "y": 8,
+        "y": 2,
         "w": 4,
         "h": 4
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(tyk_requests_with_cache_total{service_name=\"tyk-gateway\", cache_status=\"1\", api_id=\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_requests_with_cache_total{service_name=\"tyk-gateway\", api_id=\"$api_id\"}[$__rate_interval])) * 100 or vector(0)",
+          "expr": "sum(rate(tyk_requests_with_cache_total{service_name=\"tyk-gateway\", cache_status=\"1\", api_id=\"$api_id\"}[$__rate_interval])) / sum(rate(tyk_requests_with_cache_total{service_name=\"tyk-gateway\", api_id=\"$api_id\"}[$__rate_interval])) * 100",
           "instant": true
         }
       ],
@@ -531,7 +543,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 12,
+        "y": 6,
         "w": 24,
         "h": 1
       },
@@ -541,14 +553,14 @@
       "id": 21,
       "type": "timeseries",
       "title": "Latency Breakdown: Total / Gateway / Upstream (P95 + P50)",
-      "description": "The most powerful troubleshooting panel. If gateway latency is flat and upstream spikes, the backend is the culprit \u2014 no log diving needed.",
+      "description": "The most powerful troubleshooting panel. If gateway latency is flat and upstream spikes, the backend is the culprit — no log diving needed.",
       "datasource": {
         "uid": "${datasource_prometheus}",
         "type": "prometheus"
       },
       "gridPos": {
         "x": 0,
-        "y": 13,
+        "y": 7,
         "w": 12,
         "h": 9
       },
@@ -556,22 +568,26 @@
         {
           "refId": "A",
           "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "Total P95"
+          "legendFormat": "Total P95",
+          "exemplar": true
         },
         {
           "refId": "B",
           "expr": "histogram_quantile(0.50, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "Total P50"
+          "legendFormat": "Total P50",
+          "exemplar": true
         },
         {
           "refId": "C",
           "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "Gateway P95"
+          "legendFormat": "Gateway P95",
+          "exemplar": true
         },
         {
           "refId": "D",
           "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "Upstream P95"
+          "legendFormat": "Upstream P95",
+          "exemplar": true
         }
       ],
       "fieldConfig": {
@@ -579,7 +595,27 @@
           "unit": "ms",
           "custom": {
             "lineWidth": 2,
-            "fillOpacity": 8
+            "fillOpacity": 8,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
           }
         }
       },
@@ -604,7 +640,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 13,
+        "y": 7,
         "w": 6,
         "h": 9
       },
@@ -644,14 +680,14 @@
       "id": 23,
       "type": "table",
       "title": "Latency Percentile Table",
-      "description": "P50 / P95 / P99 \u00d7 Total / Gateway / Upstream \u2014 full picture in one row.",
+      "description": "P50 / P95 / P99 × Total / Gateway / Upstream — full picture in one row.",
       "datasource": {
         "uid": "${datasource_prometheus}",
         "type": "prometheus"
       },
       "gridPos": {
         "x": 18,
-        "y": 13,
+        "y": 7,
         "w": 6,
         "h": 9
       },
@@ -712,7 +748,19 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "ms"
+          "unit": "ms",
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "nan",
+                "result": {
+                  "text": "—",
+                  "color": "text"
+                }
+              }
+            }
+          ]
         }
       }
     },
@@ -720,14 +768,14 @@
       "id": 24,
       "type": "timeseries",
       "title": "P95 Latency by HTTP Method",
-      "description": "POST latency 3\u00d7 GET? Likely a request body processing issue.",
+      "description": "POST latency 3× GET? Likely a request body processing issue.",
       "datasource": {
         "uid": "${datasource_prometheus}",
         "type": "prometheus"
       },
       "gridPos": {
         "x": 0,
-        "y": 22,
+        "y": 16,
         "w": 24,
         "h": 7
       },
@@ -764,7 +812,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 29,
+        "y": 23,
         "w": 24,
         "h": 1
       },
@@ -780,7 +828,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 30,
+        "y": 24,
         "w": 8,
         "h": 8
       },
@@ -803,7 +851,14 @@
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 10
-          }
+          },
+          "links": [
+            {
+              "title": "📋 View gateway logs for this API",
+              "url": "/grafana/explore?left=%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22%7Bservice_name%3D%5C%22tyk-gateway%5C%22%7D+%7C+json+%7C+tyk_api_id%3D%5C%22${api_id}%5C%22%22%7D%5D%7D&${__url.params}",
+              "targetBlank": true
+            }
+          ]
         }
       },
       "options": {
@@ -827,7 +882,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 30,
+        "y": 24,
         "w": 6,
         "h": 8
       },
@@ -868,7 +923,7 @@
       },
       "gridPos": {
         "x": 14,
-        "y": 30,
+        "y": 24,
         "w": 5,
         "h": 8
       },
@@ -899,14 +954,14 @@
       "id": 34,
       "type": "timeseries",
       "title": "Error Rate by Route",
-      "description": "Which endpoint is failing \u2014 /checkout or /products?",
+      "description": "Which endpoint is failing — /checkout or /products?",
       "datasource": {
         "uid": "${datasource_prometheus}",
         "type": "prometheus"
       },
       "gridPos": {
         "x": 19,
-        "y": 30,
+        "y": 24,
         "w": 5,
         "h": 8
       },
@@ -946,7 +1001,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 38,
+        "y": 32,
         "w": 12,
         "h": 7
       },
@@ -986,7 +1041,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 38,
+        "y": 32,
         "w": 12,
         "h": 7
       },
@@ -1024,7 +1079,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 45,
+        "y": 44,
         "w": 24,
         "h": 1
       },
@@ -1041,7 +1096,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 46,
+        "y": 45,
         "w": 8,
         "h": 7
       },
@@ -1074,22 +1129,22 @@
     {
       "id": 42,
       "type": "timeseries",
-      "title": "Request Rate by Route",
+      "title": "Request Rate by Path",
       "datasource": {
         "uid": "${datasource_prometheus}",
         "type": "prometheus"
       },
       "gridPos": {
         "x": 8,
-        "y": 46,
+        "y": 45,
         "w": 8,
         "h": 7
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(route)(rate(tyk_requests_by_route_total{service_name=\"tyk-gateway\", api_id=\"$api_id\"}[$__rate_interval]))",
-          "legendFormat": "{{route}}"
+          "expr": "sum by(path)(rate(tyk_requests_by_route_total{service_name=\"tyk-gateway\", api_id=\"$api_id\"}[$__rate_interval]))",
+          "legendFormat": "{{path}}"
         }
       ],
       "fieldConfig": {
@@ -1121,7 +1176,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 46,
+        "y": 45,
         "w": 8,
         "h": 7
       },
@@ -1162,7 +1217,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 53,
+        "y": 52,
         "w": 12,
         "h": 7
       },
@@ -1203,7 +1258,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 53,
+        "y": 52,
         "w": 12,
         "h": 7
       },
@@ -1240,7 +1295,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 60,
+        "y": 59,
         "w": 24,
         "h": 1
       },
@@ -1257,7 +1312,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 61,
+        "y": 60,
         "w": 8,
         "h": 8
       },
@@ -1303,7 +1358,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 61,
+        "y": 60,
         "w": 8,
         "h": 8
       },
@@ -1348,7 +1403,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 61,
+        "y": 60,
         "w": 8,
         "h": 8
       },
@@ -1385,7 +1440,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 69,
+        "y": 68,
         "w": 24,
         "h": 1
       },
@@ -1402,7 +1457,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 70,
+        "y": 69,
         "w": 8,
         "h": 7
       },
@@ -1443,7 +1498,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 70,
+        "y": 69,
         "w": 8,
         "h": 7
       },
@@ -1484,7 +1539,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 70,
+        "y": 69,
         "w": 8,
         "h": 7
       },
@@ -1521,7 +1576,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 77,
+        "y": 76,
         "w": 24,
         "h": 1
       },
@@ -1531,14 +1586,14 @@
       "id": 71,
       "type": "table",
       "title": "Recent Traces",
-      "description": "Recent traces for this API. Click Trace ID to open in Tempo. Copy a trace_id and paste into the $trace_id variable above to correlate with Row 8 logs.",
+      "description": "Recent traces for this API. Click Trace ID to open in Tempo. Use '+ Filter logs by this trace' to correlate with Row 8 logs.",
       "datasource": {
         "type": "tempo",
         "uid": "${datasource_tempo}"
       },
       "gridPos": {
         "x": 0,
-        "y": 78,
+        "y": 77,
         "w": 12,
         "h": 10
       },
@@ -1624,7 +1679,19 @@
             "align": "auto",
             "displayMode": "auto",
             "filterable": true
-          }
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "nan",
+                "result": {
+                  "text": "—",
+                  "color": "text"
+                }
+              }
+            }
+          ]
         },
         "overrides": [
           {
@@ -1640,6 +1707,16 @@
                     "title": "View in Tempo",
                     "url": "/grafana/explore?left={\"datasource\":\"webstore-tempo\",\"queries\":[{\"refId\":\"A\",\"queryType\":\"traceql\",\"query\":\"${__value.raw}\"}],\"range\":{\"from\":\"now-1h\",\"to\":\"now\"}}",
                     "targetBlank": true
+                  },
+                  {
+                    "title": "+ Filter logs by this trace",
+                    "url": "/grafana/d/tyk-api-troubleshooting?from=${__from}&to=${__to}&var-api_id=${api_id}&var-tyk_gw_id=${tyk_gw_id}&var-trace_id=${__value.raw}",
+                    "targetBlank": false
+                  },
+                  {
+                    "title": "− Clear trace filter",
+                    "url": "/grafana/d/tyk-api-troubleshooting?from=${__from}&to=${__to}&var-api_id=${api_id}&var-tyk_gw_id=${tyk_gw_id}&var-trace_id=.*",
+                    "targetBlank": false
                   }
                 ]
               },
@@ -1663,7 +1740,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 78,
+        "y": 77,
         "w": 12,
         "h": 10
       },
@@ -1759,7 +1836,19 @@
             "align": "auto",
             "displayMode": "auto",
             "filterable": true
-          }
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "nan",
+                "result": {
+                  "text": "—",
+                  "color": "text"
+                }
+              }
+            }
+          ]
         },
         "overrides": [
           {
@@ -1775,6 +1864,16 @@
                     "title": "View in Tempo",
                     "url": "/grafana/explore?left={\"datasource\":\"webstore-tempo\",\"queries\":[{\"refId\":\"A\",\"queryType\":\"traceql\",\"query\":\"${__value.raw}\"}],\"range\":{\"from\":\"now-1h\",\"to\":\"now\"}}",
                     "targetBlank": true
+                  },
+                  {
+                    "title": "+ Filter logs by this trace",
+                    "url": "/grafana/d/tyk-api-troubleshooting?from=${__from}&to=${__to}&var-api_id=${api_id}&var-tyk_gw_id=${tyk_gw_id}&var-trace_id=${__value.raw}",
+                    "targetBlank": false
+                  },
+                  {
+                    "title": "− Clear trace filter",
+                    "url": "/grafana/d/tyk-api-troubleshooting?from=${__from}&to=${__to}&var-api_id=${api_id}&var-tyk_gw_id=${tyk_gw_id}&var-trace_id=.*",
+                    "targetBlank": false
                   }
                 ]
               },
@@ -1794,7 +1893,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 87,
+        "y": 86,
         "w": 24,
         "h": 1
       },
@@ -1808,7 +1907,7 @@
       "datasource": "${datasource_loki}",
       "gridPos": {
         "x": 0,
-        "y": 88,
+        "y": 87,
         "w": 24,
         "h": 9
       },
@@ -1816,7 +1915,7 @@
         {
           "refId": "A",
           "queryType": "range",
-          "expr": "{service_name=\"tyk-gateway\"} | tyk_prefix=`access-log`"
+          "expr": "{service_name=\"tyk-gateway\"} | tyk_prefix=`access-log` | tyk_trace_id=~\"$trace_id\""
         }
       ],
       "options": {
@@ -1842,7 +1941,7 @@
       "datasource": "${datasource_loki}",
       "gridPos": {
         "x": 0,
-        "y": 97,
+        "y": 96,
         "w": 12,
         "h": 9
       },
@@ -1850,7 +1949,7 @@
         {
           "refId": "A",
           "queryType": "range",
-          "expr": "{service_name=\"tyk-gateway\"} | detected_level=~`error|warn|fatal`"
+          "expr": "{service_name=\"tyk-gateway\"} | detected_level=~`error|warn|fatal` | tyk_trace_id=~\"$trace_id\""
         }
       ],
       "options": {
@@ -1869,11 +1968,11 @@
       "id": 83,
       "type": "logs",
       "title": "All Recent Logs (trace correlation)",
-      "description": "Full log stream. Paste a trace_id from Row 7 into the $trace_id variable above \u2014 when set, this panel filters to log lines containing that ID, enabling cross-service correlation.",
+      "description": "Full log stream. Paste a trace_id from Row 7 into the $trace_id variable above — when set, this panel filters to log lines containing that ID, enabling cross-service correlation.",
       "datasource": "${datasource_loki}",
       "gridPos": {
         "x": 12,
-        "y": 97,
+        "y": 96,
         "w": 12,
         "h": 9
       },
@@ -1881,7 +1980,7 @@
         {
           "refId": "A",
           "queryType": "range",
-          "expr": "{service_name=\"tyk-gateway\"}"
+          "expr": "{service_name=\"tyk-gateway\"} | tyk_trace_id=~\"$trace_id\""
         }
       ],
       "options": {
@@ -1895,6 +1994,61 @@
         "defaults": {},
         "overrides": []
       }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 9008,
+      "panels": [],
+      "title": "Tyk Response Flag Reference",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 9006,
+      "options": {
+        "content": "[Error classification docs →](https://tyk.io/docs/api-management/logs#error-classification)\n\n**Upstream and Proxy Errors**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `TLE` | TLS Certificate Expired | 502 | Upstream TLS certificate has expired |\n| `TLI` | TLS Certificate Invalid | 502 | Upstream TLS certificate failed validation |\n| `TLM` | TLS Hostname Mismatch | 502 | Certificate CN/SAN does not match hostname |\n| `TLN` | TLS Not Trusted | 502 | Certificate issued by unknown authority |\n| `TLH` | TLS Handshake Failure | 502 | TLS handshake failed |\n| `TLP` | TLS Protocol Error | 502 | TLS protocol or version mismatch |\n| `TLA` | TLS Alert | 502 | TLS alert received from upstream |\n| `UCF` | Connection Refused | 502 | Upstream refused the TCP connection |\n| `UCT` | Connection Timeout | 502 | TCP connection to upstream timed out |\n| `URR` | Connection Reset | 502 | Connection reset by upstream server |\n| `EPI` | Broken Pipe | 502 | Connection closed unexpectedly (EPIPE) |\n| `URT` | Response Timeout | 504 | Upstream did not respond in time |\n| `DNS` | DNS Resolution Failure | 502 | Upstream hostname could not be resolved |\n| `NRH` | No Route to Host | 502 | Upstream host or network unreachable |\n| `NHU` | No Healthy Upstreams | 503 | All targets in load balancer are unhealthy |\n| `CBO` | Circuit Breaker Open | 503 | Circuit breaker is open |\n| `URS` | Upstream Response 5XX | 5XX | Upstream returned a 5XX status code |\n| `UPE` | Upstream Error | 5XX | Generic upstream error |\n\n**Authentication Errors**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `AMF` | Auth Field Missing | 400/401 | Authorization header or parameter missing |\n| `AKI` | API Key Invalid | 403 | API key not found or invalid |\n| `TKE` | Token Expired | 403 | JWT, OAuth token, or client cert has expired |\n| `TKI` | Token Invalid | 403 | JWT or OAuth token malformed or bad signature |\n| `TCV` | Token Claims Invalid | 401 | JWT claims validation failed |\n| `EAD` | External Auth Denied | 403 | External auth service denied the request |\n\n**Rate Limiting**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `RLT` | Rate Limited | 429 | Request rejected due to rate limit |\n| `QEX` | Quota Exceeded | 403 | Client usage quota exhausted |\n\n**Request Validation**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `BTL` | Body Too Large | 400 | Request body exceeds configured size limit |\n| `CLM` | Content-Length Missing | 411 | Required Content-Length header missing |\n| `BIV` | Body Invalid | 400/422 | Request body malformed or fails schema validation |\n| `IHD` | Invalid Header | 400 | Required request header malformed or invalid |\n\n**Client Connection**\n\n| Flag | Name | HTTP | Description |\n|------|------|------|-------------|\n| `CDC` | Client Disconnected | 499 | Client closed connection before response sent |",
+        "mode": "markdown"
+      },
+      "title": "Tyk Response Flag Reference",
+      "type": "text"
+    }
+  ],
+  "links": [
+    {
+      "title": "🖥 Fleet Health",
+      "url": "/grafana/d/tyk-gateway-fleet-health",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "📊 API Portfolio",
+      "url": "/grafana/d/tyk-api-portfolio",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "🔍 API Troubleshooting",
+      "url": "/grafana/d/tyk-api-troubleshooting",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
     }
   ]
 }

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
@@ -2,10 +2,19 @@
   "uid": "tyk-gateway-fleet-health",
   "title": "Tyk Gateway - Fleet Health",
   "description": "Gateway node health, deployment config state, Go runtime metrics, and load distribution across the fleet. Audience: Platform Engineers / DevOps.",
-  "tags": ["tyk", "fleet", "gateway", "opentelemetry", "observability"],
+  "tags": [
+    "tyk",
+    "fleet",
+    "gateway",
+    "opentelemetry",
+    "observability"
+  ],
   "timezone": "browser",
   "refresh": "30s",
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "schemaVersion": 39,
   "version": 1,
   "templating": {
@@ -29,7 +38,10 @@
       {
         "name": "tyk_gw_id",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_gateway_apis_loaded{tyk_gw_group_id=~\"$tyk_gw_group_id\"}, tyk_gw_id)",
         "label": "Gateway Node",
         "multi": true,
@@ -42,7 +54,10 @@
       {
         "name": "tyk_gw_group_id",
         "type": "query",
-        "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
+        "datasource": {
+          "uid": "${datasource_prometheus}",
+          "type": "prometheus"
+        },
         "query": "label_values(tyk_gateway_apis_loaded, tyk_gw_group_id)",
         "label": "Group / Cluster",
         "multi": true,
@@ -57,11 +72,49 @@
   },
   "panels": [
     {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9001,
+      "panels": [
+        {
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 9002,
+          "options": {
+            "content": "## \ud83d\uddfa How to use this dashboard\n\n**Target audience**: Platform engineers, DevOps, SREs  \n**Use when**: Checking deployment health, investigating gateway node divergence\n\n| Symptom | What to look at | Next step |\n|---------|----------------|-----------|\n| \ud83d\udd34 APIs Loaded dropped on a node | \"APIs Loaded per Node\" \u2014 look for the node that diverged | Check Config Reload Rate; compare to other nodes |\n| \ud83d\udfe0 Config Reload Rate is sustained | \"Config Reload Rate\" timeseries | Gateway may be stuck in a reload loop \u2014 check tyk.conf or K8s rollout |\n| \ud83d\udd34 Go memory near limit | \"Go Memory Usage\" panel | Risk of OOM \u2014 check for memory leaks or traffic spike |\n| \u2705 Fleet healthy but users reporting issues | Nothing red here | Jump to \u2192 [API Portfolio](/grafana/d/tyk-api-portfolio) |",
+            "mode": "markdown"
+          },
+          "title": "How to use this dashboard",
+          "type": "text"
+        }
+      ],
+      "title": "\u2139\ufe0f How to use this dashboard",
+      "type": "row"
+    },
+    {
       "id": 100,
       "type": "row",
       "title": "Fleet-at-a-Glance KPIs",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
@@ -69,8 +122,16 @@
       "type": "stat",
       "title": "Gateway Nodes",
       "description": "Number of distinct gateway nodes currently reporting metrics.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
           "refId": "A",
@@ -79,15 +140,29 @@
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "value",
         "graphMode": "none",
         "textMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       }
@@ -96,13 +171,21 @@
       "id": 2,
       "type": "bargauge",
       "title": "APIs Loaded per Gateway",
-      "description": "API definitions loaded per gateway node. All nodes in the same group should show the same count — a divergence indicates a config sync issue.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "description": "API definitions loaded per gateway node. All nodes in the same group should show the same count \u2014 a divergence indicates a config sync issue.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
           "refId": "A",
-          "expr": "tyk_gateway_apis_loaded{tyk_gw_id=~\"$tyk_gw_id\"}",
+          "expr": "tyk_gateway_apis_loaded{tyk_gw_group_id=~\"$tyk_gw_group_id\", tyk_gw_id=~\"$tyk_gw_id\"}",
           "instant": true,
           "legendFormat": "{{tyk_gw_id}}"
         }
@@ -110,27 +193,49 @@
       "options": {
         "orientation": "horizontal",
         "displayMode": "basic",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "short",
-          "min": 0
+          "min": 0,
+          "links": [
+            {
+              "title": "View in API Portfolio",
+              "url": "/grafana/d/tyk-api-portfolio?var-tyk_gw_id=${__field.labels.tyk_gw_id}&from=${__from}&to=${__to}",
+              "targetBlank": false
+            }
+          ]
         }
-      }
+      },
+      "transformations": []
     },
     {
       "id": 3,
       "type": "bargauge",
       "title": "Policies Loaded per Gateway",
-      "description": "Security policies loaded per gateway node. All nodes in the same group should show the same count — a divergence indicates a policy sync issue.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+      "description": "Security policies loaded per gateway node. All nodes in the same group should show the same count \u2014 a divergence indicates a policy sync issue.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
           "refId": "A",
-          "expr": "tyk_gateway_policies_loaded{tyk_gw_id=~\"$tyk_gw_id\"}",
+          "expr": "tyk_gateway_policies_loaded{tyk_gw_group_id=~\"$tyk_gw_group_id\", tyk_gw_id=~\"$tyk_gw_id\"}",
           "instant": true,
           "legendFormat": "{{tyk_gw_id}}"
         }
@@ -138,23 +243,45 @@
       "options": {
         "orientation": "horizontal",
         "displayMode": "basic",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "short",
-          "min": 0
+          "min": 0,
+          "links": [
+            {
+              "title": "View in API Portfolio",
+              "url": "/grafana/d/tyk-api-portfolio?var-tyk_gw_id=${__field.labels.tyk_gw_id}&from=${__from}&to=${__to}",
+              "targetBlank": false
+            }
+          ]
         }
-      }
+      },
+      "transformations": []
     },
     {
       "id": 4,
       "type": "stat",
       "title": "Config Reload Rate",
       "description": "Rate of config reloads per second. Sustained high value indicates a deployment loop.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
           "refId": "A",
@@ -163,20 +290,35 @@
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "value",
         "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.1 },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "reqps"
@@ -188,8 +330,16 @@
       "type": "stat",
       "title": "Gateway Request Rate",
       "description": "Total requests per second across the fleet.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
           "refId": "A",
@@ -198,15 +348,29 @@
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "value",
         "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "reqps"
         }
       }
@@ -216,8 +380,16 @@
       "type": "stat",
       "title": "HTTP Error Rate",
       "description": "5xx responses as % of total traffic. Red threshold at 5%.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
           "refId": "A",
@@ -226,20 +398,35 @@
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 5 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
             ]
           },
           "unit": "percent",
@@ -253,7 +440,12 @@
       "type": "row",
       "title": "Deployment & Config State",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
@@ -261,8 +453,16 @@
       "type": "timeseries",
       "title": "APIs Loaded Per Gateway",
       "description": "API definition count per node over time. A drop on one node during a rolling deploy indicates a config propagation failure.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 6, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 7,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -273,18 +473,38 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 22,
       "type": "timeseries",
       "title": "Policies Loaded Per Gateway",
       "description": "Policy count per node. Divergence confirms uneven policy distribution after a push.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 6, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 7,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -295,18 +515,38 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 23,
       "type": "stat",
       "title": "Config Drift",
       "description": "Difference between the node with the most APIs loaded and the least. Green = 0 (all nodes in sync). Non-zero means at least one node is out of step.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 6, "w": 4, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 7,
+        "w": 4,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -315,7 +555,11 @@
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "none",
         "textMode": "auto",
@@ -323,12 +567,20 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short",
@@ -341,8 +593,16 @@
       "type": "bargauge",
       "title": "Per-Node API Count",
       "description": "Snapshot of API count per node. A mismatched bar means a node is out of sync with the fleet.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 20, "y": 6, "w": 4, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 7,
+        "w": 4,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -354,22 +614,37 @@
       "options": {
         "orientation": "horizontal",
         "displayMode": "gradient",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         }
-      }
+      },
+      "transformations": []
     },
     {
       "id": 25,
       "type": "timeseries",
       "title": "Config Reload Events",
       "description": "Rate of config reloads per node. Correlate reload spikes with traffic anomalies.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 13, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -380,18 +655,38 @@
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 26,
       "type": "timeseries",
       "title": "Config Reload Duration P95",
       "description": "P95 reload duration in milliseconds. Slow reloads (>30s) during high traffic can cause brief request failures.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 13, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -402,25 +697,51 @@
       "fieldConfig": {
         "defaults": {
           "unit": "ms",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 10000 },
-              { "color": "red", "value": 30000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "red",
+                "value": 30000
+              }
             ]
           }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 300,
       "type": "row",
       "title": "Go Runtime Health",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 20, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
@@ -428,8 +749,16 @@
       "type": "timeseries",
       "title": "Memory: Used / GC Goal / Limit",
       "description": "Three memory boundaries overlaid per gateway: used (runtime-tracked heap), gc_goal (heap size that will trigger GC), and limit (GOMEMLIMIT hard ceiling). Used approaching gc_goal means GC is about to run; used approaching limit means OOM risk.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 21, "w": 14, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 14,
+        "h": 8
+      },
       "targets": [
         {
           "refId": "A",
@@ -450,35 +779,84 @@
       "fieldConfig": {
         "defaults": {
           "unit": "bytes",
-          "custom": { "lineWidth": 2, "fillOpacity": 5 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
         },
         "overrides": [
           {
-            "matcher": { "id": "byFrameRefID", "options": "B" },
-            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } }]
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    8,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
           },
           {
-            "matcher": { "id": "byFrameRefID", "options": "C" },
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
             "properties": [
-              { "id": "custom.lineStyle", "value": { "dash": [2, 4], "fill": "dot" } },
-              { "id": "custom.fillOpacity", "value": 0 }
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    4
+                  ],
+                  "fill": "dot"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
             ]
           }
         ]
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 33,
       "type": "gauge",
-      "title": "Memory vs Limit",
-      "description": "Memory used as % of the GOMEMLIMIT hard ceiling per gateway. Alert threshold: 80%.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 14, "y": 21, "w": 5, "h": 8 },
+      "title": "Heap Pressure (% of GC Goal)",
+      "description": "Heap in use as a percentage of the GC trigger threshold per gateway. Values above 80% mean GC will trigger soon. Spikes indicate allocation bursts.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 14,
+        "y": 22,
+        "w": 5,
+        "h": 8
+      },
       "targets": [
         {
           "refId": "A",
-          "expr": "go_memory_used_bytes{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"} / go_memory_limit_bytes{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"} * 100",
+          "expr": "sum by(tyk_gw_id)(go_memory_used_bytes{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}) / on(tyk_gw_id) go_memory_gc_goal_bytes{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"} * 100",
           "instant": true,
           "legendFormat": "{{tyk_gw_id}}"
         }
@@ -491,26 +869,48 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 60 },
-              { "color": "red", "value": 80 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           }
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
-      }
+      },
+      "transformations": []
     },
     {
       "id": 34,
       "type": "bargauge",
       "title": "Goroutine Fleet Snapshot",
       "description": "Instant goroutine count per node. Outliers indicate a goroutine leak on that specific gateway.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 19, "y": 21, "w": 5, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 19,
+        "y": 22,
+        "w": 5,
+        "h": 8
+      },
       "targets": [
         {
           "refId": "A",
@@ -522,22 +922,37 @@
       "options": {
         "orientation": "horizontal",
         "displayMode": "gradient",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         }
-      }
+      },
+      "transformations": []
     },
     {
       "id": 31,
       "type": "timeseries",
       "title": "Goroutines vs GOMAXPROCS",
       "description": "Goroutine count per gateway overlaid with GOMAXPROCS (processor limit). Goroutines far exceeding GOMAXPROCS indicate heavy scheduler contention. Steady upward drift in goroutines indicates a leak.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 29, "w": 8, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 30,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -553,80 +968,142 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         },
         "overrides": [
           {
-            "matcher": { "id": "byFrameRefID", "options": "B" },
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
             "properties": [
-              { "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } },
-              { "id": "custom.fillOpacity", "value": 0 }
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    8,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
             ]
           }
         ]
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 36,
       "type": "timeseries",
       "title": "Allocation Rate",
-      "description": "Rate of bytes allocated by the Go runtime per second. Allocation spikes often precede GC spikes by a few seconds — useful for root-cause analysis of latency blips.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 8, "y": 29, "w": 8, "h": 7 },
+      "description": "Rate of bytes allocated by the Go runtime per second. Allocation spikes often precede GC spikes by a few seconds \u2014 useful for root-cause analysis of latency blips.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 30,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
-          "expr": "rate(go_memory_allocations_bytes_total{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])",
+          "expr": "rate(go_memory_allocated_bytes_total{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])",
           "legendFormat": "{{tyk_gw_id}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "Bps",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 35,
       "type": "timeseries",
-      "title": "Goroutine Scheduling Latency (P50/P95/P99)",
-      "description": "Goroutine scheduling latency percentiles in milliseconds. Elevated P99 indicates runtime scheduler pressure — caused by GC stop-the-world pauses, goroutine starvation, or CPU saturation.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 16, "y": 29, "w": 8, "h": 7 },
+      "title": "Object Allocation Rate",
+      "description": "Heap objects allocated per second per gateway. High object count with low byte rate indicates many small short-lived allocations, which increases GC frequency. Complements the byte allocation rate panel.",
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 30,
+        "w": 8,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.50, sum by(le, tyk_gw_id)(rate(go_schedule_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "P50 {{tyk_gw_id}}"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le, tyk_gw_id)(rate(go_schedule_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "P95 {{tyk_gw_id}}"
-        },
-        {
-          "refId": "C",
-          "expr": "histogram_quantile(0.99, sum by(le, tyk_gw_id)(rate(go_schedule_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
-          "legendFormat": "P99 {{tyk_gw_id}}"
+          "expr": "rate(go_memory_allocations_total{service_name=\"tyk-gateway\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])",
+          "legendFormat": "{{tyk_gw_id}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "ms",
-          "custom": { "lineWidth": 2, "fillOpacity": 5 }
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 400,
       "type": "row",
       "title": "Gateway Traffic & Load Distribution",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 36, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
@@ -634,8 +1111,16 @@
       "type": "timeseries",
       "title": "Request Rate by Gateway",
       "description": "Requests per second per node. Uneven load distribution is immediately visible.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 36, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -646,18 +1131,45 @@
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "links": [
+            {
+              "title": "View in API Portfolio",
+              "url": "/grafana/d/tyk-api-portfolio?${__url.params}&var-tyk_gw_id=${__series.name}",
+              "targetBlank": false
+            }
+          ]
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 42,
       "type": "timeseries",
       "title": "Error Rate by Gateway",
       "description": "5xx error rate per node. A node with elevated errors indicates infra or config issue on that node.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 36, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 37,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -669,18 +1181,45 @@
         "defaults": {
           "unit": "percent",
           "min": 0,
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "links": [
+            {
+              "title": "View in API Portfolio",
+              "url": "/grafana/d/tyk-api-portfolio?${__url.params}&var-tyk_gw_id=${__series.name}",
+              "targetBlank": false
+            }
+          ]
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 43,
       "type": "timeseries",
       "title": "P95 Latency by Gateway",
       "description": "P95 total request latency per node in ms. A slow node points to infra or resource contention.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 0, "y": 43, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 44,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -691,18 +1230,58 @@
       "fieldConfig": {
         "defaults": {
           "unit": "ms",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "transformations": []
     },
     {
       "id": 44,
       "type": "piechart",
       "title": "Traffic Share by Gateway Node",
       "description": "Percentage of total fleet traffic handled by each node. Uneven slices indicate load balancer misconfiguration.",
-      "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-      "gridPos": { "x": 12, "y": 43, "w": 12, "h": 7 },
+      "datasource": {
+        "uid": "${datasource_prometheus}",
+        "type": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 44,
+        "w": 12,
+        "h": 7
+      },
       "targets": [
         {
           "refId": "A",
@@ -712,30 +1291,52 @@
       ],
       "options": {
         "pieType": "pie",
-        "displayLabels": ["percent", "name"],
-        "legend": { "displayMode": "list", "placement": "right" }
+        "displayLabels": [
+          "percent",
+          "name"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        }
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         }
-      }
+      },
+      "transformations": []
     },
     {
       "id": 500,
       "type": "row",
       "title": "Edge & Multi-Region (Tyk Cloud / Distributed)",
       "collapsed": true,
-      "gridPos": { "x": 0, "y": 50, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 51,
+        "w": 24,
+        "h": 1
+      },
       "panels": [
         {
           "id": 51,
           "type": "piechart",
           "title": "Dataplane vs Control Plane Traffic",
           "description": "Traffic split between dataplane (edge) nodes and control plane nodes.",
-          "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-          "gridPos": { "x": 0, "y": 51, "w": 8, "h": 7 },
+          "datasource": {
+            "uid": "${datasource_prometheus}",
+            "type": "prometheus"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 52,
+            "w": 8,
+            "h": 7
+          },
           "targets": [
             {
               "refId": "A",
@@ -745,18 +1346,39 @@
           ],
           "options": {
             "pieType": "pie",
-            "displayLabels": ["percent", "name"],
-            "legend": { "displayMode": "list", "placement": "right" }
+            "displayLabels": [
+              "percent",
+              "name"
+            ],
+            "legend": {
+              "displayMode": "list",
+              "placement": "right"
+            }
           },
-          "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              }
+            }
+          }
         },
         {
           "id": 52,
           "type": "timeseries",
           "title": "Traffic by Edge Cluster",
           "description": "Request rate per cluster/group. Useful for multi-region and Tyk Cloud deployments.",
-          "datasource": { "uid": "${datasource_prometheus}", "type": "prometheus" },
-          "gridPos": { "x": 8, "y": 51, "w": 16, "h": 7 },
+          "datasource": {
+            "uid": "${datasource_prometheus}",
+            "type": "prometheus"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 52,
+            "w": 16,
+            "h": 7
+          },
           "targets": [
             {
               "refId": "A",
@@ -764,8 +1386,24 @@
               "legendFormat": "{{tyk_gw_group_id}}"
             }
           ],
-          "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 10 } } },
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 10
+              }
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
         }
       ]
     },
@@ -774,7 +1412,12 @@
       "type": "row",
       "title": "Gateway Health Events",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 51, "w": 24, "h": 1 },
+      "gridPos": {
+        "x": 0,
+        "y": 52,
+        "w": 24,
+        "h": 1
+      },
       "panels": []
     },
     {
@@ -782,34 +1425,85 @@
       "type": "timeseries",
       "title": "Gateway Error Rate (from logs)",
       "description": "Count of error/warn/fatal operational log events over time. Spikes indicate gateway-internal issues: OTLP export failures, connection errors, or panics.",
-      "datasource": { "uid": "${datasource_loki}", "type": "loki" },
-      "gridPos": { "x": 0, "y": 52, "w": 12, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_loki}",
+        "type": "loki"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 53,
+        "w": 8,
+        "h": 8
+      },
       "targets": [
         {
           "refId": "A",
           "queryType": "range",
-          "instant": false,
-          "range": true,
-          "expr": "sum(count_over_time({service_name=\"tyk-gateway\"} | detected_level=~`error|warn|fatal` [5m]))",
-          "legendFormat": "errors"
+          "expr": "sum(count_over_time({service_name=~\".+\"} | service_name=\"tyk-gateway\" | detected_level=\"error\" [$__interval]))",
+          "legendFormat": "error"
+        },
+        {
+          "refId": "B",
+          "queryType": "range",
+          "expr": "sum(count_over_time({service_name=~\".+\"} | service_name=\"tyk-gateway\" | detected_level=\"warn\" [$__interval]))",
+          "legendFormat": "warn"
+        },
+        {
+          "refId": "C",
+          "queryType": "range",
+          "expr": "sum(count_over_time({service_name=~\".+\"} | service_name=\"tyk-gateway\" | detected_level=\"info\" [$__interval]))",
+          "legendFormat": "info"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "custom": { "lineWidth": 2, "fillOpacity": 20 },
-          "color": { "mode": "fixed", "fixedColor": "red" }
-        }
+          "custom": {
+            "drawStyle": "bars",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "error" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "warn" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "info" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          }
+        ]
       },
-      "options": { "tooltip": { "mode": "single" }, "legend": { "displayMode": "hidden" } }
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
     },
     {
       "id": 62,
       "type": "table",
       "title": "Upstream Failures by API",
       "description": "Individual 5xx responses from gateway access logs. Each row is one failed request showing the API, response flag, and status code.",
-      "datasource": { "uid": "${datasource_loki}", "type": "loki" },
-      "gridPos": { "x": 12, "y": 52, "w": 12, "h": 8 },
+      "datasource": {
+        "uid": "${datasource_loki}",
+        "type": "loki"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 61,
+        "w": 24,
+        "h": 10
+      },
       "targets": [
         {
           "refId": "A",
@@ -819,10 +1513,26 @@
           "expr": "{service_name=\"tyk-gateway\"} | tyk_prefix=`access-log` | tyk_status=~`5..`"
         }
       ],
-      "options": { "sortBy": [{ "displayName": "Time", "desc": true }] },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": {
+        "sortBy": [
+          {
+            "displayName": "Time",
+            "desc": true
+          }
+        ]
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "transformations": [
-        { "id": "extractFields", "options": { "source": "labels", "format": "json" } },
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "labels",
+            "format": "json"
+          }
+        },
         {
           "id": "organize",
           "options": {
@@ -853,8 +1563,16 @@
       "type": "logs",
       "title": "Recent Gateway Errors",
       "description": "Live stream of error, warn, and fatal log entries from gateway operational logs. Expand an entry to see full JSON context including component, message, and error details.",
-      "datasource": { "uid": "${datasource_loki}", "type": "loki" },
-      "gridPos": { "x": 0, "y": 60, "w": 24, "h": 10 },
+      "datasource": {
+        "uid": "${datasource_loki}",
+        "type": "loki"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 53,
+        "w": 16,
+        "h": 8
+      },
       "targets": [
         {
           "refId": "A",
@@ -863,7 +1581,7 @@
         }
       ],
       "options": {
-        "dedupStrategy": "none",
+        "dedupStrategy": "signature",
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showTime": true,
@@ -872,6 +1590,29 @@
         "wrapLogMessage": true,
         "sortOrder": "Descending"
       }
+    }
+  ],
+  "links": [
+    {
+      "title": "\ud83d\udda5 Fleet Health",
+      "url": "/grafana/d/tyk-gateway-fleet-health",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "\ud83d\udcca API Portfolio",
+      "url": "/grafana/d/tyk-api-portfolio",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "\ud83d\udd0d API Troubleshooting",
+      "url": "/grafana/d/tyk-api-troubleshooting",
+      "type": "link",
+      "targetBlank": false,
+      "icon": "external link"
     }
   ]
 }


### PR DESCRIPTION
Improves readability and correctness across the Tyk OTLP Grafana dashboard suite.

**API Portfolio**: Top 10 leaderboard bargauges now show human-readable API names instead of raw UUIDs, using a `label_replace + group_left(api_name)` join with `tyk_requests_by_route_total`. The "Latency by API" table filter key is fixed from `API ID` to `api_id` so clicking a row correctly scopes the dashboard variable.

**API Troubleshooting**: "Request Rate by Route" renamed to "Request Rate by Path" and switched to the `path` label, which carries actual URL paths (e.g. `/basic-open-api/anything/1`).

**Fleet Health**: "Gateway Error Rate (from logs)" converted to a stacked bar chart (error/warn/info colour-coded per level) with a corrected Loki stream selector (`{service_name=~".+"}`) and `[$__interval]` to fix empty data. "Recent Gateway Errors" and "Upstream Failures by API" panels are swapped and "Recent Gateway Errors" is widened to 2/3 of the row.

**Docs**: README updated with per-dashboard descriptions, demo talking points, and a suggested 15-minute demo flow. SKILL.md updated with the API name join pattern, Loki stream selector workaround, `path` label discovery, provisioned dashboard edit guidance, and fleet health panel layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)