### PR TITLE
opentelemetry-demo: add Grafana Cloud integration

### DIFF
--- a/deployments/opentelemetry-demo/README.md
+++ b/deployments/opentelemetry-demo/README.md
@@ -32,6 +32,50 @@ All configuration defaults for this deployment — demo app settings, service po
 
 To modify any setting, either edit [`demo.env`](./demo.env) directly or add the variable to your `.env` file. Variables in `.env` take precedence over `demo.env`.
 
+## Grafana Cloud Integration
+
+All telemetry can be forwarded to Grafana Cloud alongside the local backends. Local services (Jaeger, Tempo, Prometheus, Loki, OpenSearch) continue running — Grafana Cloud is an additional destination.
+
+### Prerequisites
+
+You need three values from your Grafana Cloud stack:
+
+| Variable | Description | Where to find it |
+| -------- | ----------- | ---------------- |
+| `GRAFANA_CLOUD_OTLP_ENDPOINT` | OTLP gateway URL for your region | Home → Connections → Add new connection → OpenTelemetry |
+| `GRAFANA_CLOUD_INSTANCE_ID` | Your numeric Grafana Cloud instance ID | Same page — listed as "Instance ID" or "Username" |
+| `GRAFANA_CLOUD_API_KEY` | A Grafana Cloud API token with MetricsPublisher + LogsPublisher + TracesPublisher scopes | Home → Administration → Service accounts → Add service account token |
+
+Region endpoints:
+- EU: `https://otlp-gateway-prod-eu-west-2.grafana.net/otlp`
+- US East: `https://otlp-gateway-prod-us-east-0.grafana.net/otlp`
+- AP Southeast: `https://otlp-gateway-prod-ap-southeast-1.grafana.net/otlp`
+
+### Setup
+
+**Step 1** — Set the environment variables in your `.env` file (takes precedence over `demo.env`):
+
+```
+GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+GRAFANA_CLOUD_INSTANCE_ID=<your instance ID>
+GRAFANA_CLOUD_API_KEY=<your API token>
+```
+
+**Step 2** — Uncomment all sections in [`src/otel-collector/otelcol-config-extras.yml`](./src/otel-collector/otelcol-config-extras.yml):
+remove the leading `# ` from every line in the `exporters`, `processors`, `extensions`, `connectors`, and `service` blocks.
+
+**Step 3** — Restart the deployment:
+
+```
+./up.sh opentelemetry-demo
+```
+
+To verify, check the collector logs for any authentication errors:
+
+```
+docker logs otel-collector 2>&1 | grep -i "grafana\|export\|error"
+```
+
 ## Grafana Dashboards
 
 Grafana is available at **http://localhost:8085/grafana** (no login required).

--- a/deployments/opentelemetry-demo/demo.env
+++ b/deployments/opentelemetry-demo/demo.env
@@ -210,3 +210,14 @@ TEMPO_HTTP_PORT=3200
 PROMETHEUS_PORT=9090
 PROMETHEUS_HOST=prometheus
 PROMETHEUS_ADDR=${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
+
+# ********************
+# Grafana Cloud
+# ********************
+# Set these variables and uncomment all sections in otelcol-config-extras.yml
+# to forward telemetry (traces, metrics, logs) to Grafana Cloud.
+# Find your credentials at: Home → Connections → Add new connection → OpenTelemetry
+# Regions: prod-eu-west-2 (EU), prod-us-east-0 (US East), prod-ap-southeast-1 (AP)
+# GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-eu-west-2.grafana.net/otlp
+# GRAFANA_CLOUD_INSTANCE_ID=
+# GRAFANA_CLOUD_API_KEY=

--- a/deployments/opentelemetry-demo/docker-compose.yml
+++ b/deployments/opentelemetry-demo/docker-compose.yml
@@ -901,6 +901,9 @@ services:
       - POSTGRES_PORT
       - POSTGRES_PASSWORD
       - GOMEMLIMIT=400MiB
+      - GRAFANA_CLOUD_OTLP_ENDPOINT
+      - GRAFANA_CLOUD_INSTANCE_ID
+      - GRAFANA_CLOUD_API_KEY
 
   # Prometheus
   prometheus:

--- a/deployments/opentelemetry-demo/src/otel-collector/otelcol-config-extras.yml
+++ b/deployments/opentelemetry-demo/src/otel-collector/otelcol-config-extras.yml
@@ -1,18 +1,32 @@
-# Copyright The OpenTelemetry Authors
-# SPDX-License-Identifier: Apache-2.0
+# # Copyright The OpenTelemetry Authors
+# # SPDX-License-Identifier: Apache-2.0
 
-# extra settings to be merged into OpenTelemetry Collector configuration
-# do not delete this file
+# # extra settings to be merged into OpenTelemetry Collector configuration
+# # do not delete this file
 
-## Example configuration for sending data to your own OTLP HTTP backend
-## Note: the spanmetrics exporter must be included in the exporters array
-## if overriding the traces pipeline.
-##
-#
+# # Grafana Cloud Integration
+# # -------------------------
+# # To forward all telemetry (traces, metrics, logs) to Grafana Cloud:
+# #
+# #   1. Set the following environment variables (in .env or demo.env):
+# #        GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+# #        GRAFANA_CLOUD_INSTANCE_ID=<your numeric instance ID>
+# #        GRAFANA_CLOUD_API_KEY=<your Grafana Cloud API token>
+# #
+# #      Find these in Grafana Cloud: Home → Connections → Add new connection → OpenTelemetry
+# #      Regions: prod-eu-west-2 (EU), prod-us-east-0 (US East), prod-ap-southeast-1 (AP)
+# #
+# #   2. Uncomment all sections below (exporters, processors, extensions, connectors, service).
+# #
+# #   3. Restart the deployment: ./up.sh opentelemetry-demo
+# #
+# # Note: local backends (Jaeger, Tempo, Prometheus, Loki, OpenSearch) continue to receive
+# # telemetry — Grafana Cloud is added as an additional destination.
+
 # exporters:
 #   otlphttp/grafana_cloud:
 #     # https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter
-#     endpoint: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"
+#     endpoint: ${env:GRAFANA_CLOUD_OTLP_ENDPOINT}
 #     auth:
 #       authenticator: basicauth/grafana_cloud
 
@@ -69,8 +83,8 @@
 #   basicauth/grafana_cloud:
 #     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension
 #     client_auth:
-#       username: ""
-#       password: ""
+#       username: ${env:GRAFANA_CLOUD_INSTANCE_ID}
+#       password: ${env:GRAFANA_CLOUD_API_KEY}
 
 # connectors:
 #   grafanacloud:
@@ -86,11 +100,12 @@
 #     traces:
 #       processors:
 #         [resourcedetection, memory_limiter, transform, transform/drop_unneeded_resource_attributes, batch]
-#       exporters: [otlp, debug, spanmetrics, otlphttp/grafana_cloud, grafanacloud]
+#       exporters: [otlp, otlp/tempo, debug, spanmetrics, otlphttp/grafana_cloud, grafanacloud]
 #     metrics:
 #       processors:
 #         [
 #           resourcedetection, memory_limiter,
+#           transform/tyk_gw_resource_attrs,
 #           transform/drop_unneeded_resource_attributes,
 #           transform/add_resource_attributes_as_metric_attributes,
 #           batch
@@ -102,4 +117,4 @@
 #       exporters: [otlphttp/grafana_cloud]
 #     logs:
 #       processors: [resourcedetection, memory_limiter, transform/drop_unneeded_resource_attributes, batch]
-#       exporters: [opensearch, debug, otlphttp/grafana_cloud]
+#       exporters: [opensearch, otlphttp/loki, debug, otlphttp/grafana_cloud]


### PR DESCRIPTION
## Summary

- Adds `otelcol-config-extras.yml` template for forwarding traces, metrics, and logs to Grafana Cloud via OTLP, using env vars for credentials instead of hard-coded empty strings
- Passes the three `GRAFANA_CLOUD_*` env vars into the `otel-collector` container via `docker-compose.yml` so the collector can resolve them at startup
- Adds a `Grafana Cloud` section to `demo.env` with the required variables pre-documented as comments
- Adds a **Grafana Cloud Integration** section to `README.md` with credential requirements, region endpoints, and step-by-step activation instructions

Local backends (Jaeger, Tempo, Prometheus, Loki, OpenSearch) continue running alongside — Grafana Cloud is an additional destination, not a replacement.