### PR TITLE
Fix Latency Breakdown y-axis: use seconds instead of milliseconds

### DIFF
--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-troubleshooting.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-troubleshooting.json
@@ -573,32 +573,32 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])))",
           "legendFormat": "Total P95",
           "exemplar": true
         },
         {
           "refId": "B",
-          "expr": "histogram_quantile(0.50, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
+          "expr": "histogram_quantile(0.50, sum by(le)(rate(http_server_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])))",
           "legendFormat": "Total P50",
           "exemplar": true
         },
         {
           "refId": "C",
-          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_gateway_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])))",
           "legendFormat": "Gateway P95",
           "exemplar": true
         },
         {
           "refId": "D",
-          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval]))) * 1000",
+          "expr": "histogram_quantile(0.95, sum by(le)(rate(tyk_upstream_request_duration_seconds_bucket{service_name=\"tyk-gateway\", tyk_api_id=\"$api_id\", tyk_gw_id=~\"$tyk_gw_id\"}[$__rate_interval])))",
           "legendFormat": "Upstream P95",
           "exemplar": true
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "ms",
+          "unit": "s",
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 8,
@@ -615,11 +615,11 @@
               },
               {
                 "color": "yellow",
-                "value": 200
+                "value": 0.2
               },
               {
                 "color": "red",
-                "value": 500
+                "value": 0.5
               }
             ]
           }


### PR DESCRIPTION
## Summary
- The "Latency Breakdown" panel in the API Troubleshooting dashboard was multiplying histogram queries by 1000 and displaying values in milliseconds, causing exemplars (which Prometheus stores natively in seconds) to appear 1000× out of position on the y-axis.
- Removed `* 1000` from all 4 panel queries and changed the unit from `ms` to `s`.
- Updated threshold values from 200/500 to 0.2/0.5 to match the new unit.

## Test Plan
- [ ] Open the API Troubleshooting dashboard in Grafana
- [ ] Confirm the Latency Breakdown y-axis shows values in seconds (e.g. ~0.02s, not 20ms)
- [ ] Confirm exemplar dots align with the time series lines