### PR TITLE
Fix error rate panels exceeding 100% and correct RLT flag name

### DIFF
--- a/deployments/opentelemetry-demo/scripts/gateway-signals-report.sh
+++ b/deployments/opentelemetry-demo/scripts/gateway-signals-report.sh
@@ -389,8 +389,8 @@ run_and_capture_scenario() {
        s_desc="5 requests with \`x-api-key: invalid-key-xyz\`. Expected: all **403** (\`response_flag: AKI\`)." ;;
     3) s_name="S3 · R04: Quota Exhaustion (QEX)"
        s_desc="35 requests with key-low (quota=30). Expected: first 30 → **200**, last 5 → **403** (\`response_flag: QEX\`)." ;;
-    4) s_name="S4 · R05: Rate Limit Rejections (TRL)"
-       s_desc="20 rapid requests with key-mid (rate=10/s). Expected: at least one **429** (\`response_flag: TRL\`)." ;;
+    4) s_name="S4 · R05: Rate Limit Rejections (RLT)"
+       s_desc="20 rapid requests with key-mid (rate=10/s). Expected: at least one **429** (\`response_flag: RLT\`)." ;;
     5) s_name="S5 · R01: High Error Rate"
        s_desc="20 requests: 5 valid (key-mid) + 15 with no key. Expected: ~75% error rate (≥15 × **401**)." ;;
     6) s_name="S6 · R02: Upstream Latency Spike"

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
@@ -851,7 +851,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(\n  sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n  / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n  * 100\n)\n* on(tyk_api_id) group_left(api_name)\n  label_replace(\n    max by(api_id, api_name)(tyk_requests_by_path_total{service_name=~\"$service_name\"}),\n    \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n  )",
+          "expr": "(\n  sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n  / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n  * 100\n)\n* on(tyk_api_id) group_left(api_name)\n  (0 * label_replace(\n    max by(api_id, api_name)(tyk_requests_by_path_total{service_name=~\"$service_name\"}),\n    \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n  ) + 1)",
           "legendFormat": "{{api_name}}"
         }
       ],
@@ -899,7 +899,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(10,\n  (\n    sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    * 100\n  )\n  * on(tyk_api_id) group_left(api_name)\n    label_replace(\n      max by(api_id, api_name)(tyk_requests_by_path_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    )\n)",
+          "expr": "topk(10,\n  (\n    sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    * 100\n  )\n  * on(tyk_api_id) group_left(api_name)\n    (0 * label_replace(\n      max by(api_id, api_name)(tyk_requests_by_path_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    ) + 1)\n)",
           "legendFormat": "{{api_name}}",
           "instant": true
         }
@@ -1231,7 +1231,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(10,\n  (\n    sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    * 100\n  )\n  * on(tyk_api_id) group_left(api_name)\n    label_replace(\n      max by(api_id, api_name)(tyk_requests_by_path_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    )\n)",
+          "expr": "topk(10,\n  (\n    sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", http_response_status_code=~\"5..\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    / sum by(tyk_api_id)(rate(tyk_api_requests_total{service_name=~\"$service_name\", tyk_gw_id=~\"$tyk_gw_id\", tyk_api_id=~\"$api_id\", http_request_method=~\"$method\"}[$__rate_interval]))\n    * 100\n  )\n  * on(tyk_api_id) group_left(api_name)\n    (0 * label_replace(\n      max by(api_id, api_name)(tyk_requests_by_path_total{service_name=~\"$service_name\"}),\n      \"tyk_api_id\", \"$1\", \"api_id\", \"(.*)\"\n    ) + 1)\n)",
           "legendFormat": "{{api_name}}",
           "instant": true
         }


### PR DESCRIPTION
## Summary
- Fix error rate PromQL expressions in the Tyk API Portfolio dashboard: panels were calculating rates > 100% because the `group_left` join multiplied percentages by raw metric counts; replaced with `(0 * label_replace(...) + 1)` to preserve the `api_name` label without scaling the value.
- Fix response flag name in `gateway-signals-report.sh`: scenario S4 referenced `TRL` but the correct flag is `RLT`.

## Test Plan
- [ ] Verify error rate panels in the Tyk API Portfolio dashboard stay within 0–100%
- [ ] Run `gateway-signals-report.sh` and confirm S4 scenario description shows `RLT`