### PR TITLE
Add Grafana alerting rules for Tyk Gateway

### DIFF
--- a/deployments/opentelemetry-demo/demo.env
+++ b/deployments/opentelemetry-demo/demo.env
@@ -212,6 +212,12 @@ PROMETHEUS_HOST=prometheus
 PROMETHEUS_ADDR=${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
 
 # ********************
+# Grafana Alerting
+# ********************
+# Set TYK_ALERTING_WEBHOOK_URL in your .env to receive alert notifications
+TYK_ALERTING_WEBHOOK_URL=
+
+# ********************
 # Grafana Cloud
 # ********************
 # Set these variables and uncomment all sections in otelcol-config-extras.yml

--- a/deployments/opentelemetry-demo/docker-compose.yml
+++ b/deployments/opentelemetry-demo/docker-compose.yml
@@ -849,6 +849,7 @@ services:
     restart: unless-stopped
     environment:
       - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource"
+      - TYK_ALERTING_WEBHOOK_URL
     volumes:
       - ./deployments/opentelemetry-demo/src/grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./deployments/opentelemetry-demo/src/grafana/provisioning/:/etc/grafana/provisioning/

--- a/deployments/opentelemetry-demo/scripts/continuous-traffic-gen.js
+++ b/deployments/opentelemetry-demo/scripts/continuous-traffic-gen.js
@@ -21,7 +21,7 @@
  */
 
 import http from 'k6/http';
-import { check } from 'k6';
+import { check, sleep } from 'k6';
 import encoding from 'k6/encoding';
 
 // ─── Config ────────────────────────────────────────────────────────────────────
@@ -305,9 +305,10 @@ export function setup() {
     hook_references: [], is_site: false, sort_by: 0, user_group_owners: [], user_owners: [],
   });
 
-  // 4. Reload gateway so APIs are registered
+  // 4. Reload gateway so APIs are registered; sleep to allow propagation
   console.log('Reloading gateway after API creation...');
   reloadGateway();
+  sleep(3);
 
   // 5. Create OAuth access policy
   console.log('Creating policies...');
@@ -351,9 +352,10 @@ export function setup() {
     },
   });
 
-  // 7. Reload gateway to sync new policies
+  // 7. Reload gateway to sync new policies; sleep to allow policy propagation
   console.log('Reloading gateway to sync policies...');
   reloadGateway();
+  sleep(5);
 
   // 8. Create quota API keys
   console.log('Creating keys...');
@@ -382,7 +384,7 @@ export function setup() {
       }),
       { headers: authHeaders() }
     );
-    console.log(`  OAuth client: ${resp.json('client_id')}`);
+    console.log(`  OAuth client: ${client.id} (${resp.json('Message') || resp.status})`);
   }
 
   // 10. Get initial access tokens for each OAuth client

--- a/deployments/opentelemetry-demo/src/grafana/grafana.ini
+++ b/deployments/opentelemetry-demo/src/grafana/grafana.ini
@@ -343,7 +343,7 @@ serve_from_sub_path = true
 ;min_refresh_interval = 5s
 
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
-default_home_dashboard_path = /etc/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
+;default_home_dashboard_path = /etc/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
 
 #################################### Users ###############################
 [users]
@@ -373,7 +373,7 @@ default_home_dashboard_path = /etc/grafana/provisioning/dashboards/tyk-demo/tyk-
 ;default_theme = dark
 
 # Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
-;home_page =
+home_page = /dashboards/f/tyk-demo/tyk-demo
 
 # External user management, these options affect the organization users view
 ;external_manage_link_url =

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/alerting/tyk-contact-points.yml
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/alerting/tyk-contact-points.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: 1
+contactPoints:
+  - orgId: 1
+    name: tyk-webhook
+    receivers:
+      - uid: tyk-webhook
+        type: webhook
+        settings:
+          url: ${TYK_ALERTING_WEBHOOK_URL}

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/alerting/tyk-gateway-alerting.yml
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/alerting/tyk-gateway-alerting.yml
@@ -1,0 +1,473 @@
+---
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: tyk-gateway
+    folder: tyk-demo
+    interval: 1m
+    rules:
+
+      # Error rate > 10% over 5 minutes
+      - uid: tyk-high-error-rate
+        title: TykHighErrorRate
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                rate(tyk_api_requests_total{http_response_status_code!~"2.."}[5m])
+                /
+                rate(tyk_api_requests_total[5m])
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.10
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "Error rate > 10% for {{ $labels.tyk_api_id }}"
+          description: >-
+            The non-2xx error rate has exceeded 10% for 5 minutes.
+            Check response flag breakdown in the Tyk API dashboard to identify the error source.
+        labels:
+          severity: warning
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # p95 latency > 1 second over 5 minutes
+      - uid: tyk-high-latency
+        title: TykHighLatency
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                histogram_quantile(0.95,
+                  rate(http_server_request_duration_seconds_bucket[5m])
+                )
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "p95 latency > 1s for {{ $labels.tyk_api_id }}"
+          description: >-
+            p95 end-to-end latency has exceeded 1 second for 5 minutes.
+            If gateway-only latency (tyk_gateway_request_duration_seconds) is < 10ms, the bottleneck is upstream.
+        labels:
+          severity: warning
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # Auth failure surge (AMF or AKI) > 0.1/s for 2 minutes
+      - uid: tyk-auth-failure-surge
+        title: TykAuthFailureSurge
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                rate(http_server_request_duration_seconds_count{tyk_response_flag=~"AMF|AKI"}[5m])
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.1
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        noDataState: NoData
+        execErrState: Error
+        for: 2m
+        annotations:
+          summary: "Auth failures > 6/min — client misconfiguration or credential attack"
+          description: >-
+            AMF (missing auth header) or AKI (invalid key) rate exceeds 0.1/s.
+            Single source IP suggests misconfigured client; wide IP spread suggests credential stuffing.
+        labels:
+          severity: warning
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # Quota exhaustion (QEX) — any sustained for 1 minute
+      - uid: tyk-quota-exhaustion
+        title: TykQuotaExhaustion
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                rate(http_server_request_duration_seconds_count{tyk_response_flag="QEX"}[5m])
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        annotations:
+          summary: "Consumers hitting quota limits (QEX)"
+          description: >-
+            One or more consumers have exhausted their quota window.
+            Identify the consumer via the api_key field in logs and consider raising their quota or inviting a tier upgrade.
+        labels:
+          severity: info
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # Rate limit rejections (RLT) — any sustained for 1 minute
+      - uid: tyk-rate-limit-rejections
+        title: TykRateLimitRejections
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                rate(http_server_request_duration_seconds_count{tyk_response_flag="RLT"}[1m])
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        annotations:
+          summary: "Rate limit rejections (RLT)"
+          description: >-
+            Requests are being rejected by the rate limiter.
+            If RLT rate is climbing alongside overall request rate, clients may be retrying 429s without backoff (retry storm).
+        labels:
+          severity: info
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # Upstream 5xx errors (URS) — any sustained for 3 minutes
+      - uid: tyk-upstream-errors
+        title: TykUpstreamErrors
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                rate(http_server_request_duration_seconds_count{tyk_response_flag="URS"}[5m])
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        noDataState: NoData
+        execErrState: Error
+        for: 3m
+        annotations:
+          summary: "Upstream returning 5xx for {{ $labels.tyk_api_id }}"
+          description: >-
+            The upstream service is returning 5xx errors (URS flag).
+            Extract error_target and upstream_addr from logs and escalate to the backend team.
+        labels:
+          severity: critical
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # Goroutine count > 5,000 for 10 minutes
+      - uid: tyk-goroutine-growth
+        title: TykGoroutineGrowth
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                go_goroutine_count{job="tyk-gateway"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - 5000
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        dashboardUid: tyk-gateway-fleet-health
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        annotations:
+          summary: "Goroutine count elevated — possible leak"
+          description: >-
+            go_goroutine_count has exceeded 5,000 for 10 minutes on {{ $labels.service_instance_id }}.
+            A healthy gateway at moderate load runs 500–2,000 goroutines.
+            Enable http_profiler and capture a goroutine profile to investigate.
+        labels:
+          severity: warning
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook
+
+      # API definition count dropped > 10% in 2 minutes
+      - uid: tyk-apis-loaded-drop
+        title: TykApisLoadedDrop
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: webstore-metrics
+            model:
+              editorMode: code
+              expr: |-
+                (tyk_gateway_apis_loaded - tyk_gateway_apis_loaded offset 2m)
+                  / tyk_gateway_apis_loaded offset 2m
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    params:
+                      - -0.1
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+        dashboardUid: tyk-gateway-fleet-health
+        noDataState: NoData
+        execErrState: Error
+        for: 0s
+        annotations:
+          summary: "API definition count dropped > 10% — possible sync failure"
+          description: >-
+            tyk_gateway_apis_loaded dropped more than 10% in a 2-minute window.
+            This typically indicates a failed sync from the Dashboard or an accidental bulk delete.
+            Check gateway logs for config sync errors.
+        labels:
+          severity: critical
+        isPaused: false
+        notification_settings:
+          receiver: tyk-webhook

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/demo.yaml
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/demo.yaml
@@ -15,8 +15,7 @@ providers:
       path: /etc/grafana/provisioning/dashboards/demo
   - name: 'Tyk Demo'
     orgId: 1
-    folder: 'Tyk Demo'
-    folderUid: 'tyk-demo'
+    folder: 'tyk-demo'
     type: file
     disableDeletion: false
     editable: true

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-api-portfolio.json
@@ -866,7 +866,7 @@
           "links": [
             {
               "title": "🔍 Troubleshoot this API",
-              "url": "/grafana/d/tyk-api-troubleshooting?${__url.params}&var-api_id=${__field.labels.tyk_api_id}",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}",
               "targetBlank": false
             }
           ]
@@ -923,7 +923,7 @@
           "links": [
             {
               "title": "🔍 Troubleshoot this API",
-              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}&from=${__from}&to=${__to}",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}",
               "targetBlank": false
             }
           ]
@@ -1143,7 +1143,7 @@
           "links": [
             {
               "title": "🔍 Troubleshoot this API",
-              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.api_id}&from=${__from}&to=${__to}",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.api_id}",
               "targetBlank": false
             }
           ]
@@ -1190,7 +1190,7 @@
           "links": [
             {
               "title": "🔍 Troubleshoot this API",
-              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}&from=${__from}&to=${__to}",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}",
               "targetBlank": false
             }
           ],
@@ -1255,7 +1255,7 @@
           "links": [
             {
               "title": "🔍 Troubleshoot this API",
-              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}&from=${__from}&to=${__to}",
+              "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__field.labels.tyk_api_id}",
               "targetBlank": false
             }
           ]
@@ -1401,7 +1401,7 @@
                 "value": [
                   {
                     "title": "🔍 Troubleshoot this API",
-                    "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__value.text}&${__url.params}",
+                    "url": "/grafana/d/tyk-api-troubleshooting?var-api_id=${__value.text}",
                     "targetBlank": false
                   }
                 ]

--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-gateway-fleet-health.json
@@ -214,7 +214,7 @@
           "links": [
             {
               "title": "View in API Portfolio",
-              "url": "/grafana/d/tyk-api-portfolio?var-tyk_gw_id=${__field.labels.tyk_gw_id}&from=${__from}&to=${__to}",
+              "url": "/grafana/d/tyk-api-portfolio?var-tyk_gw_id=${__field.labels.tyk_gw_id}",
               "targetBlank": false
             }
           ]
@@ -264,7 +264,7 @@
           "links": [
             {
               "title": "View in API Portfolio",
-              "url": "/grafana/d/tyk-api-portfolio?var-tyk_gw_id=${__field.labels.tyk_gw_id}&from=${__from}&to=${__to}",
+              "url": "/grafana/d/tyk-api-portfolio?var-tyk_gw_id=${__field.labels.tyk_gw_id}",
               "targetBlank": false
             }
           ]


### PR DESCRIPTION
## Summary
- Adds 8 provisioned Grafana alert rules covering high error rate, high latency, auth failure surge, quota exhaustion, rate limit rejections, upstream 5xx errors, goroutine growth, and API definition count drops — each routing to a configurable webhook contact point (`TYK_ALERTING_WEBHOOK_URL`)
- Fixes dashboard inter-panel deep links to drop redundant URL params, and updates Grafana home page to redirect to the Tyk Demo folder
- Fixes `continuous-traffic-gen.js` to sleep after gateway reloads for config propagation

## Test Plan
- [ ] Set `TYK_ALERTING_WEBHOOK_URL` in `.env` and start the stack; verify alert rules appear in Grafana → Alerting → Alert rules
- [ ] Confirm webhook contact point is provisioned under Grafana → Alerting → Contact points
- [ ] Check dashboard links navigate correctly without stale time range params