### PR TITLE
Fix Grafana startup errors in opentelemetry-demo

### DIFF
--- a/deployments/opentelemetry-demo/demo.env
+++ b/deployments/opentelemetry-demo/demo.env
@@ -215,7 +215,7 @@ PROMETHEUS_ADDR=${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
 # Grafana Alerting
 # ********************
 # Set TYK_ALERTING_WEBHOOK_URL in your .env to receive alert notifications
-TYK_ALERTING_WEBHOOK_URL=
+TYK_ALERTING_WEBHOOK_URL=http://localhost/webhook
 
 # ********************
 # Grafana Cloud

--- a/deployments/opentelemetry-demo/src/grafana/grafana.ini
+++ b/deployments/opentelemetry-demo/src/grafana/grafana.ini
@@ -373,7 +373,7 @@ serve_from_sub_path = true
 ;default_theme = dark
 
 # Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
-home_page = /dashboards/f/tyk-demo/tyk-demo
+home_page = /dashboards/
 
 # External user management, these options affect the organization users view
 ;external_manage_link_url =


### PR DESCRIPTION
## Summary
- Set `TYK_ALERTING_WEBHOOK_URL` to a placeholder URL in `demo.env` so Grafana provisioning validation passes when no real webhook is configured (was causing a fatal startup error)
- Fix `home_page` path in `grafana.ini` to `/dashboards/` (removes reference to non-existent folder path)

## Test Plan
- [ ] Start the stack with `docker compose --env-file deployments/opentelemetry-demo/demo.env -f deployments/opentelemetry-demo/docker-compose.yml up grafana`
- [ ] Confirm no `ProvisioningServiceImpl run error` in Grafana logs
- [ ] Confirm Grafana UI loads at the configured port

🤖 Generated with [Claude Code](https://claude.com/claude-code)