### PR TITLE
[TT-17030] Migrate from ORG_GH_TOKEN PAT to GitHub App token

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -13,6 +13,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Git - checkout pull request branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -26,4 +34,4 @@ jobs:
           yamllint_strict: strict
           yamllint_comment: true
         env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` in `linters.yaml` (`GITHUB_ACCESS_TOKEN` env var for yamllint action) with a token generated by `actions/create-github-app-token`

### Files changed
- `.github/workflows/linters.yaml` — yamllint job's `GITHUB_ACCESS_TOKEN` env var

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` org-level secrets are available to this repo
- [ ] Push a commit and confirm the yamllint job runs successfully with the app token

🤖 Generated with [Claude Code](https://claude.com/claude-code)