### PR TITLE
Fix MCP metrics dashboard to truly exclude non-MCP traffic

### DIFF
--- a/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-mcp-metrics.json
+++ b/deployments/opentelemetry-demo/src/grafana/provisioning/dashboards/tyk-demo/tyk-mcp-metrics.json
@@ -37,7 +37,7 @@
         "name": "api_id",
         "type": "query",
         "datasource": "${datasource_prometheus}",
-        "query": "label_values(tyk_mcp_requests_total{service_name=~\"$service_name\"}, tyk_api_id)",
+        "query": "label_values(tyk_mcp_requests_total{service_name=~\"$service_name\", mcp_method_name!=\"\"}, tyk_api_id)",
         "current": { "text": "All", "value": "$__all" },
         "multi": true,
         "includeAll": true,
@@ -108,7 +108,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "sum(rate(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval]))",
+          "expr": "sum(rate(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval]))",
           "legendFormat": "req/s",
           "refId": "A"
         }
@@ -126,7 +126,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "100 * (sum(rate(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\", http_response_status_code=~\"[45]..\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])), 1)",
+          "expr": "100 * (sum(rate(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\", http_response_status_code=~\"[45]..\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])), 1)",
           "legendFormat": "% errors",
           "refId": "A"
         }
@@ -144,7 +144,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "count(count by(mcp_primitive_name)(rate(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\"}[$__range])))",
+          "expr": "count(count by(mcp_primitive_name)(rate(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\"}[$__range])))",
           "legendFormat": "tools",
           "refId": "A"
         }
@@ -153,8 +153,8 @@
     {
       "id": 4,
       "type": "stat",
-      "title": "Active MCP Sessions",
-      "description": "Distinct Mcp-Session-Id values seen on http.server.request.duration in the time window. Requires the mcp.session.id dimension on http.server.request.duration.",
+      "title": "MCP Sessions Started",
+      "description": "Count of MCP initialize requests in the selected time range.",
       "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
       "datasource": "${datasource_prometheus}",
       "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } }, "overrides": [] },
@@ -162,7 +162,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "count(count by(mcp_session_id)(rate(http_server_request_duration_seconds_count{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_session_id!=\"\"}[$__range])))",
+          "expr": "sum(increase(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=\"initialize\"}[$__range])) or vector(0)",
           "legendFormat": "sessions",
           "refId": "A"
         }
@@ -180,7 +180,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "1000 * histogram_quantile(0.95, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
+          "expr": "1000 * histogram_quantile(0.95, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{mcp_primitive_type!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "refId": "A"
         }
@@ -198,7 +198,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "topk(1, sum by(mcp_primitive_name)(rate(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\"}[5m])))",
+          "expr": "topk(1, sum by(mcp_primitive_name)(rate(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\"}[5m])))",
           "legendFormat": "{{mcp_primitive_name}}",
           "refId": "A"
         }
@@ -225,7 +225,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "sum by(mcp_method_name)(rate(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval]))",
+          "expr": "sum by(mcp_method_name)(rate(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval]))",
           "legendFormat": "{{mcp_method_name}}",
           "refId": "A"
         }
@@ -243,7 +243,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "sum by(mcp_primitive_type)(increase(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__range]))",
+          "expr": "sum by(mcp_primitive_type)(increase(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_method_name=~\"$mcp_method\", mcp_primitive_type=~\"$primitive_type\"}[$__range]))",
           "legendFormat": "{{mcp_primitive_type}}",
           "refId": "A"
         }
@@ -270,19 +270,19 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "1000 * histogram_quantile(0.50, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
+          "expr": "1000 * histogram_quantile(0.50, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{mcp_primitive_type!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "1000 * histogram_quantile(0.95, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
+          "expr": "1000 * histogram_quantile(0.95, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{mcp_primitive_type!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "1000 * histogram_quantile(0.99, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
+          "expr": "1000 * histogram_quantile(0.99, sum by(le)(rate(tyk_mcp_primitive_duration_seconds_bucket{mcp_primitive_type!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\"}[$__rate_interval])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -300,7 +300,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "1000 * histogram_quantile(0.95, sum by(le, mcp_primitive_name)(rate(tyk_mcp_primitive_duration_seconds_bucket{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\", mcp_primitive_name!=\"\"}[$__rate_interval])))",
+          "expr": "1000 * histogram_quantile(0.95, sum by(le, mcp_primitive_name)(rate(tyk_mcp_primitive_duration_seconds_bucket{mcp_primitive_type!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_type=~\"$primitive_type\", mcp_primitive_name!=\"\"}[$__rate_interval])))",
           "legendFormat": "{{mcp_primitive_name}}",
           "refId": "A"
         }
@@ -327,7 +327,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "topk(20, sum by(mcp_primitive_type, mcp_primitive_name)(increase(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\"}[$__range])))",
+          "expr": "topk(20, sum by(mcp_primitive_type, mcp_primitive_name)(increase(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\"}[$__range])))",
           "legendFormat": "",
           "format": "table",
           "instant": true,
@@ -350,7 +350,7 @@
       "targets": [
         {
           "datasource": "${datasource_prometheus}",
-          "expr": "topk(20, sum by(mcp_primitive_type, mcp_primitive_name, http_response_status_code)(increase(tyk_mcp_requests_total{service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\", http_response_status_code=~\"[45]..\"}[$__range])))",
+          "expr": "topk(20, sum by(mcp_primitive_type, mcp_primitive_name, http_response_status_code)(increase(tyk_mcp_requests_total{mcp_method_name!=\"\", service_name=~\"$service_name\", tyk_api_id=~\"$api_id\", mcp_primitive_name!=\"\", http_response_status_code=~\"[45]..\"}[$__range])))",
           "legendFormat": "",
           "format": "table",
           "instant": true,


### PR DESCRIPTION
## Problem

The MCP metrics Grafana dashboard in `opentelemetry-demo` showed non-MCP traffic in most panels. Root cause: the gateway emits `tyk.mcp.requests.total` and `tyk.mcp.primitive.duration` for **every** request (MCP dimensions default to `""` in `TYK_GW_OPENTELEMETRY_METRICS_APIMETRICS`), so non-MCP APIs (cart-api, checkout-api, frontend, …) appear as series with an empty `mcp_method_name`. PromQL `=~".*"` — the dashboard's *All* variable value — matches empty/absent labels, so those series were included everywhere.

## Fix

- Add `mcp_method_name!=""` to every `tyk_mcp_requests_total` query and `mcp_primitive_type!=""` to every `tyk_mcp_primitive_duration_seconds` query.
- Source the `api_id` variable from `tyk_mcp_requests_total{mcp_method_name!=""}` so it only lists APIs that actually serve MCP traffic. The variable has no custom `allValue`, so *All* expands to the enumerated MCP API list — which also scopes the trace/spanmetrics panels (which have no MCP dimension) to MCP APIs.
- Replace the **Active MCP Sessions** panel — it queried an `mcp_session_id` label that no configured metric emits, so it was always empty — with **MCP Sessions Started** based on `initialize` request counts.

## Verification

Verified against a running deployment: before the fix, 8 non-MCP APIs polluted `tyk_mcp_requests_total`; with the fixed queries, only the MCP API's series remain, the `api_id` dropdown lists only the MCP API, and the sessions panel returns real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)